### PR TITLE
feat(encode): Vulkan H.264 encoder with tuned hardware settings, loca…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ runelite-cache/
 .env
 run-with-plugin.bat
 CLAUDE.md
+install.sh

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,10 @@ def runeLiteVersion = 'latest.release'
 dependencies {
 	compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
 
-	// Vulkan Video Encode support (pure Java, no native jars)
-	// compileOnly: classes exist at compile time but loaded conditionally at runtime
-	// via reflection in EncoderFallbackChain to gracefully degrade when unavailable
-	compileOnly 'org.lwjgl:lwjgl-vulkan:3.3.4'
+	// Vulkan Video Encode support. LWJGL 3.3.6 still exposes the provisional EXT
+	// class names, but the struct layouts and numeric sType values match the
+	// ratified KHR extension, so the same bindings work against modern drivers.
+	compileOnly 'org.lwjgl:lwjgl-vulkan:3.3.6'
 
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
@@ -37,4 +37,54 @@ version = '1.0.0'
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
 	options.release.set(11)
+}
+
+// Standalone MJPEG -> MP4 test runner. Separate classpath because the plugin
+// declares lwjgl-vulkan as compileOnly (RuneLite provides it at runtime); the
+// test needs real natives.
+configurations {
+	mjpegTool
+}
+
+dependencies {
+	mjpegTool 'org.lwjgl:lwjgl:3.3.6'
+	mjpegTool 'org.lwjgl:lwjgl:3.3.6:natives-linux'
+	mjpegTool 'org.lwjgl:lwjgl-vulkan:3.3.6'
+	mjpegTool 'org.projectlombok:lombok:1.18.30'
+	mjpegTool 'org.slf4j:slf4j-simple:2.0.13'
+}
+
+task dumpBitstream(type: JavaExec) {
+	group = 'verification'
+	dependsOn classes
+	mainClass = 'com.osrstracker.video.encode.DumpBitstream'
+	classpath = sourceSets.main.output + configurations.mjpegTool
+	systemProperty 'org.lwjgl.system.stackSize', '1024'
+	systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', 'warn'
+	if (project.hasProperty('mjpeg')) { args project.property('mjpeg') }
+}
+
+task dumpSpsPps(type: JavaExec) {
+	group = 'verification'
+	dependsOn classes
+	mainClass = 'com.osrstracker.video.encode.DumpSpsPps'
+	classpath = sourceSets.main.output + configurations.mjpegTool
+	systemProperty 'org.lwjgl.system.stackSize', '1024'
+	systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', 'warn'
+	if (project.hasProperty('mjpeg')) { args project.property('mjpeg') }
+}
+
+task runMjpegTool(type: JavaExec) {
+	group = 'verification'
+	description = 'Drive VulkanEncoder against an MJPEG file and write a faststart MP4.'
+	dependsOn classes
+	mainClass = 'com.osrstracker.video.encode.MjpegToMp4Tool'
+	classpath = sourceSets.main.output + configurations.mjpegTool
+	systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', 'info'
+	// Video struct pNext chains + extension enumeration overflow the default 64 KB stack.
+	systemProperty 'org.lwjgl.system.stackSize', '1024'
+	if (project.hasProperty('mjpeg') && project.hasProperty('out')) {
+		args project.property('mjpeg'), project.property('out'),
+			 project.hasProperty('fps') ? project.property('fps') : '30'
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,8 @@ def runeLiteVersion = 'latest.release'
 dependencies {
 	compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
 
-	// Vulkan Video Encode support. LWJGL 3.3.6 still exposes the provisional EXT
-	// class names, but the struct layouts and numeric sType values match the
-	// ratified KHR extension, so the same bindings work against modern drivers.
-	compileOnly 'org.lwjgl:lwjgl-vulkan:3.3.6'
+	// Bundled at runtime: RuneLite ships lwjgl core but not lwjgl-vulkan.
+	implementation 'org.lwjgl:lwjgl-vulkan:3.3.6'
 
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
@@ -39,9 +37,8 @@ tasks.withType(JavaCompile).configureEach {
 	options.release.set(11)
 }
 
-// Standalone MJPEG -> MP4 test runner. Separate classpath because the plugin
-// declares lwjgl-vulkan as compileOnly (RuneLite provides it at runtime); the
-// test needs real natives.
+// Standalone MJPEG -> MP4 test runner. Separate classpath so it can pull in
+// the native lwjgl jars that the RuneLite runtime doesn't need.
 configurations {
 	mjpegTool
 }

--- a/src/main/java/com/osrstracker/OsrsTrackerConfig.java
+++ b/src/main/java/com/osrstracker/OsrsTrackerConfig.java
@@ -163,6 +163,23 @@ public interface OsrsTrackerConfig extends Config
         return "";
     }
 
+    /*
+     * Default true so existing configurations (users already running with an
+     * API token) keep uploading as before. Still opt-in overall: if the API
+     * token is blank, uploads are silently off regardless of this setting.
+     */
+    @ConfigItem(
+        keyName = "uploadToPlatform",
+        name = "Upload Clips to Platform",
+        description = "Send captured clips to osrs-tracker.com. Disable to keep clips local only. Has no effect without an API token.",
+        section = apiSection,
+        position = 2
+    )
+    default boolean uploadToPlatform()
+    {
+        return true;
+    }
+
     // ===== Tracking Options =====
 
     @ConfigItem(

--- a/src/main/java/com/osrstracker/OsrsTrackerPanel.java
+++ b/src/main/java/com/osrstracker/OsrsTrackerPanel.java
@@ -293,11 +293,17 @@ public class OsrsTrackerPanel extends PluginPanel
      */
     public void setReadyState()
     {
+        setReadyState(false);
+    }
+
+    public void setReadyState(boolean vulkanActive)
+    {
+        String readyText = vulkanActive ? "Vulkan encoding ready" : "Vulkan't";
         SwingUtilities.invokeLater(() -> {
             captureButton.setEnabled(true);
             captureButton.setText("Quick Capture");
             captureButton.setBackground(new Color(93, 173, 226));
-            statusLabel.setText("Ready to capture");
+            statusLabel.setText(readyText);
             statusLabel.setForeground(COLOR_READY);
         });
     }

--- a/src/main/java/com/osrstracker/OsrsTrackerPlugin.java
+++ b/src/main/java/com/osrstracker/OsrsTrackerPlugin.java
@@ -58,6 +58,7 @@ import com.osrstracker.itemsnitch.ItemSnitchButton;
 import com.osrstracker.bingo.BingoSubscriptionManager;
 import com.osrstracker.bingo.BingoProgressReporter;
 import com.osrstracker.pets.PetTracker;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import net.runelite.client.ui.overlay.OverlayManager;
 
@@ -105,7 +106,7 @@ public class OsrsTrackerPlugin extends Plugin
 
     // Raid boss NPC IDs for secondary detection via onActorDeath.
     // Primary raid detection uses KC chat messages (see checkForRaidCompletion).
-    // CoX is intentionally omitted — Great Olm can behave as an Object, making death detection unreliable.
+    // CoX is intentionally omitted: Great Olm can behave as an Object, making death detection unreliable.
     // ToB - Verzik Vitur phase 3 (both variants)
     private static final int[] VERZIK_VITUR_P3_IDS = {8374, 8375};
     // ToA - Tumeken's Warden (damaged/enraged states)
@@ -221,6 +222,7 @@ public class OsrsTrackerPlugin extends Plugin
 
         // Create the sidebar panel with quick capture button and bingo manager
         panel = new OsrsTrackerPanel(this::triggerQuickCapture, bingoSubscriptionManager);
+        panel.setReadyState(videoRecorder.isVulkanEncoderActive());
 
         // Load icon for sidebar
         BufferedImage icon = ImageUtil.loadImageResource(getClass(), "quick_capture_icon.png");
@@ -321,17 +323,6 @@ public class OsrsTrackerPlugin extends Plugin
             return;
         }
 
-        if (!apiClient.isConfigurationValid())
-        {
-            log.error("Cannot quick capture: API URL or token not configured");
-            panel.setErrorState("Configure API first!");
-            clientThread.invokeLater(() ->
-                client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "OSRS Tracker: Please configure API URL and token first!", null)
-            );
-            quickCaptureInProgress.set(false); // Reset since we're not actually capturing
-            return;
-        }
-
         // quickCaptureInProgress is already set to true by compareAndSet above
 
         // Update UI to recording state
@@ -393,7 +384,9 @@ public class OsrsTrackerPlugin extends Plugin
                 startCooldownTimer();
             },
             // Encoding start callback - called when recording stops and encoding begins
-            () -> panel.setEncodingState()
+            () -> panel.setEncodingState(),
+            EventKind.QUICK_CAPTURE,
+            null
         );
     }
 
@@ -417,7 +410,7 @@ public class OsrsTrackerPlugin extends Plugin
 
             if (remainingSeconds <= 0)
             {
-                panel.setReadyState();
+                panel.setReadyState(videoRecorder.isVulkanEncoderActive());
                 cooldownExecutor.shutdown();
             }
             else
@@ -500,7 +493,7 @@ public class OsrsTrackerPlugin extends Plugin
      *
      * Raid KC messages arrive as GAMEMESSAGE ("Your completed Chambers of Xeric count is: 52").
      * The generic "Congratulations - your raid is complete!" can arrive as FRIENDSCHATNOTIFICATION,
-     * but we don't need it — the KC message that follows is more reliable and names the raid.
+     * but we don't need it: the KC message that follows is more reliable and names the raid.
      */
     @Subscribe
     public void onChatMessage(ChatMessage chatMessage)
@@ -574,7 +567,7 @@ public class OsrsTrackerPlugin extends Plugin
 
     /**
      * Check if the message is a raid kill count message and report the completion.
-     * This is the primary raid completion detection — more reliable than NPC death events.
+     * This is the primary raid completion detection, more reliable than NPC death events.
      */
     private void checkForRaidCompletion(String message)
     {

--- a/src/main/java/com/osrstracker/api/ApiClient.java
+++ b/src/main/java/com/osrstracker/api/ApiClient.java
@@ -93,10 +93,16 @@ public class ApiClient
         String apiUrl = OsrsTrackerConfig.getEffectiveApiUrl();
         String apiToken = config.apiToken();
 
-        // Validate configuration before attempting to send
         if (!isConfigurationValid())
         {
-            log.warn("API URL or token not configured, cannot send {}", eventDescription);
+            if (config.apiToken().isEmpty())
+            {
+                log.warn("API token not configured, skipping {}", eventDescription);
+            }
+            else
+            {
+                log.debug("Platform uploads disabled, skipping {}", eventDescription);
+            }
             return;
         }
 
@@ -178,6 +184,11 @@ public class ApiClient
     public boolean isConfigurationValid()
     {
         if (config.apiToken().isEmpty())
+        {
+            return false;
+        }
+
+        if (!config.uploadToPlatform())
         {
             return false;
         }

--- a/src/main/java/com/osrstracker/bingo/BingoProgressReporter.java
+++ b/src/main/java/com/osrstracker/bingo/BingoProgressReporter.java
@@ -28,6 +28,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.osrstracker.OsrsTrackerConfig;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
@@ -136,7 +137,7 @@ public class BingoProgressReporter
                     screenshot != null ? "yes" : "no",
                     videoKey != null ? videoKey : "none");
                 sendProgress("npc_kill", eventData, screenshot, videoKey);
-            }, null);
+            }, EventKind.BINGO, npcName);
         }
         else
         {

--- a/src/main/java/com/osrstracker/collectionlog/CollectionLogTracker.java
+++ b/src/main/java/com/osrstracker/collectionlog/CollectionLogTracker.java
@@ -27,6 +27,7 @@ package com.osrstracker.collectionlog;
 import com.google.gson.JsonObject;
 import com.osrstracker.OsrsTrackerConfig;
 import com.osrstracker.api.ApiClient;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -106,7 +107,6 @@ public class CollectionLogTracker
      */
     private void sendCollectionLogUpdateToApi(String itemName)
     {
-        // Capture video with the collection log event
         videoRecorder.captureEventVideo((screenshotBase64, videoBase64) -> {
             JsonObject payload = new JsonObject();
             payload.addProperty("item_name", itemName);
@@ -119,6 +119,6 @@ public class CollectionLogTracker
                 screenshotBase64,
                 videoBase64
             );
-        });
+        }, EventKind.COLLECTION_LOG, itemName);
     }
 }

--- a/src/main/java/com/osrstracker/death/DeathTracker.java
+++ b/src/main/java/com/osrstracker/death/DeathTracker.java
@@ -30,6 +30,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Player;
 import com.osrstracker.OsrsTrackerConfig;
 import com.osrstracker.api.ApiClient;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -90,7 +91,9 @@ public class DeathTracker
                 );
             },
             null,
-            DEATH_POST_EVENT_MS
+            DEATH_POST_EVENT_MS,
+            EventKind.DEATH,
+            "death"
         );
     }
 }

--- a/src/main/java/com/osrstracker/loot/LootTracker.java
+++ b/src/main/java/com/osrstracker/loot/LootTracker.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.osrstracker.OsrsTrackerConfig;
 import com.osrstracker.api.ApiClient;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemComposition;
@@ -154,7 +155,6 @@ public class LootTracker
      */
     private void sendLootDropToApi(String sourceName, LootDropData lootData)
     {
-        // Capture video with the loot drop event
         videoRecorder.captureEventVideo((screenshotBase64, videoBase64) -> {
             JsonObject payload = new JsonObject();
             payload.addProperty("source", sourceName);
@@ -168,7 +168,7 @@ public class LootTracker
                 screenshotBase64,
                 videoBase64
             );
-        });
+        }, EventKind.LOOT, sourceName);
     }
 
     /**

--- a/src/main/java/com/osrstracker/pets/PetTracker.java
+++ b/src/main/java/com/osrstracker/pets/PetTracker.java
@@ -27,6 +27,7 @@ package com.osrstracker.pets;
 import com.google.gson.JsonObject;
 import com.osrstracker.OsrsTrackerConfig;
 import com.osrstracker.api.ApiClient;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -265,7 +266,6 @@ public class PetTracker
             payload.addProperty("player_name", localPlayer.getName());
         }
 
-        // Capture video with standard duration (6s buffer + 4s post)
         videoRecorder.captureEventVideo((screenshotBase64, videoBase64) -> {
             String eventDescription = isDuplicate
                 ? "Duplicate pet: " + petName
@@ -280,6 +280,6 @@ public class PetTracker
             );
 
             log.debug("Pet drop event sent to API: {}", eventDescription);
-        });
+        }, EventKind.PET, petName);
     }
 }

--- a/src/main/java/com/osrstracker/quest/QuestTracker.java
+++ b/src/main/java/com/osrstracker/quest/QuestTracker.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.osrstracker.OsrsTrackerConfig;
 import com.osrstracker.api.ApiClient;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -260,7 +261,6 @@ public class QuestTracker
      */
     private void sendQuestCompletionToApi(String questName)
     {
-        // Capture video with the quest completion event
         videoRecorder.captureEventVideo((screenshotBase64, videoBase64) -> {
             JsonObject payload = new JsonObject();
             payload.addProperty("quest_name", questName);
@@ -272,6 +272,6 @@ public class QuestTracker
                 screenshotBase64,
                 videoBase64
             );
-        });
+        }, EventKind.QUEST, questName);
     }
 }

--- a/src/main/java/com/osrstracker/skills/SkillLevelTracker.java
+++ b/src/main/java/com/osrstracker/skills/SkillLevelTracker.java
@@ -27,6 +27,7 @@ package com.osrstracker.skills;
 import com.google.gson.JsonObject;
 import com.osrstracker.OsrsTrackerConfig;
 import com.osrstracker.api.ApiClient;
+import com.osrstracker.video.EventKind;
 import com.osrstracker.video.VideoRecorder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -263,7 +264,6 @@ public class SkillLevelTracker
      */
     private void sendLevelUpToApi(Skill skill, int oldLevel, int newLevel)
     {
-        // Capture screenshot and video for level-ups
         videoRecorder.captureEventVideo((screenshotBase64, videoBase64) -> {
             JsonObject payload = new JsonObject();
             payload.addProperty("skill", skill.getName());
@@ -277,6 +277,6 @@ public class SkillLevelTracker
                 screenshotBase64,
                 videoBase64
             );
-        });
+        }, EventKind.LEVEL_UP, skill.getName() + "_" + newLevel);
     }
 }

--- a/src/main/java/com/osrstracker/video/AsyncFrameCapture.java
+++ b/src/main/java/com/osrstracker/video/AsyncFrameCapture.java
@@ -79,6 +79,12 @@ public class AsyncFrameCapture
     // to prevent drift when game FPS doesn't evenly divide capture FPS
     private long nextCaptureTimeNs = 0;
 
+    // Plugin startUp() registers this listener before RuneLite's GPU plugin has
+    // a GL context on the render thread. Allow a grace window of missed frames
+    // before declaring GL unavailable.
+    private static final int GL_GRACE_FRAMES = 600;
+    private int glMissedFrames = 0;
+
     /**
      * @param drawManager The RuneLite DrawManager for frame listeners
      * @param recorder The VideoRecorder to submit encoded frames to
@@ -108,6 +114,7 @@ public class AsyncFrameCapture
         firstFrame = true;
         pboIndex = 0;
         nextCaptureTimeNs = 0;
+        glMissedFrames = 0;
 
         everyFrameListener = this::onFrame;
         drawManager.registerEveryFrameListener(everyFrameListener);
@@ -203,19 +210,27 @@ public class AsyncFrameCapture
             }
             catch (IllegalStateException e)
             {
-                pboUnsupported = true;
-                log.debug("No OpenGL context available, triggering fallback");
-                onPboUnsupported.run();
+                if (++glMissedFrames > GL_GRACE_FRAMES)
+                {
+                    pboUnsupported = true;
+                    log.debug("No OpenGL context after {} frames, triggering fallback", glMissedFrames);
+                    onPboUnsupported.run();
+                }
                 return;
             }
 
             if (caps == null || !caps.OpenGL21)
             {
-                pboUnsupported = true;
-                log.debug("OpenGL 2.1 not available, triggering fallback");
-                onPboUnsupported.run();
+                if (++glMissedFrames > GL_GRACE_FRAMES)
+                {
+                    pboUnsupported = true;
+                    log.debug("OpenGL 2.1 unavailable after {} frames, triggering fallback", glMissedFrames);
+                    onPboUnsupported.run();
+                }
                 return;
             }
+
+            glMissedFrames = 0;
 
             int width, height;
             try (MemoryStack stack = MemoryStack.stackPush())

--- a/src/main/java/com/osrstracker/video/EventKind.java
+++ b/src/main/java/com/osrstracker/video/EventKind.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video;
+
+public enum EventKind
+{
+    QUICK_CAPTURE("quick_captures"),
+    LEVEL_UP("level_ups"),
+    QUEST("quests"),
+    LOOT("loot"),
+    DEATH("deaths"),
+    PET("pets"),
+    COLLECTION_LOG("collection_logs"),
+    CLUE_SCROLL("clue_scrolls"),
+    BINGO("bingo"),
+    GENERIC("");
+
+    private final String subfolder;
+
+    EventKind(String subfolder)
+    {
+        this.subfolder = subfolder;
+    }
+
+    public String subfolder()
+    {
+        return subfolder;
+    }
+}

--- a/src/main/java/com/osrstracker/video/SoftwareFrameCapture.java
+++ b/src/main/java/com/osrstracker/video/SoftwareFrameCapture.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.osrstracker.video;
+
+import net.runelite.api.BufferProvider;
+import net.runelite.api.Client;
+import net.runelite.client.ui.DrawManager;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * CPU-rasterizer fallback for {@link AsyncFrameCapture}. Reads ARGB pixels
+ * directly from {@link Client#getBufferProvider()} when no GL context is
+ * available (e.g. the GPU plugin is disabled). Flips Y on conversion so the
+ * encoder sees the same bottom-up RGBA layout as the PBO path.
+ */
+public class SoftwareFrameCapture
+{
+    private final DrawManager drawManager;
+    private final Client client;
+    private final VideoRecorder recorder;
+
+    private final AtomicBoolean shutdownRequested = new AtomicBoolean(false);
+    private Runnable everyFrameListener;
+    private long nextCaptureTimeNs = 0;
+
+    public SoftwareFrameCapture(DrawManager drawManager, Client client, VideoRecorder recorder)
+    {
+        this.drawManager = drawManager;
+        this.client = client;
+        this.recorder = recorder;
+    }
+
+    public void start()
+    {
+        if (everyFrameListener != null)
+        {
+            return;
+        }
+        shutdownRequested.set(false);
+        nextCaptureTimeNs = 0;
+        everyFrameListener = this::onFrame;
+        drawManager.registerEveryFrameListener(everyFrameListener);
+    }
+
+    public void stop()
+    {
+        shutdownRequested.set(true);
+        if (everyFrameListener != null)
+        {
+            drawManager.unregisterEveryFrameListener(everyFrameListener);
+            everyFrameListener = null;
+        }
+    }
+
+    private void onFrame()
+    {
+        if (shutdownRequested.get() || !recorder.isCurrentlyRecording())
+        {
+            return;
+        }
+
+        int captureFps = recorder.getCaptureFps();
+        if (captureFps <= 0)
+        {
+            return;
+        }
+
+        long nowNs = System.nanoTime();
+        long frameIntervalNs = 1_000_000_000L / captureFps;
+        if (nextCaptureTimeNs == 0)
+        {
+            nextCaptureTimeNs = nowNs;
+        }
+        if (nowNs < nextCaptureTimeNs)
+        {
+            return;
+        }
+        nextCaptureTimeNs += frameIntervalNs;
+        if (nowNs - nextCaptureTimeNs > frameIntervalNs)
+        {
+            nextCaptureTimeNs = nowNs + frameIntervalNs;
+        }
+
+        if (!recorder.canAcceptFrame())
+        {
+            return;
+        }
+
+        BufferProvider bp = client.getBufferProvider();
+        int[] argb = bp.getPixels();
+        int width = bp.getWidth();
+        int height = bp.getHeight();
+        if (argb == null || width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        byte[] rgba = new byte[width * height * 4];
+        for (int y = 0; y < height; y++)
+        {
+            int srcRow = y * width;
+            int dstRow = (height - 1 - y) * width * 4;
+            for (int x = 0; x < width; x++)
+            {
+                int pixel = argb[srcRow + x];
+                int dst = dstRow + (x << 2);
+                rgba[dst]     = (byte) ((pixel >> 16) & 0xFF);
+                rgba[dst + 1] = (byte) ((pixel >> 8) & 0xFF);
+                rgba[dst + 2] = (byte) (pixel & 0xFF);
+                rgba[dst + 3] = (byte) 0xFF;
+            }
+        }
+
+        recorder.submitCapturedFrame(ByteBuffer.wrap(rgba), width, height);
+    }
+}

--- a/src/main/java/com/osrstracker/video/VideoRecorder.java
+++ b/src/main/java/com/osrstracker/video/VideoRecorder.java
@@ -61,17 +61,8 @@ import com.google.gson.JsonObject;
 
 /**
  * Orchestrates video capture, encoding, and upload for gameplay events.
- *
- * Delegates frame encoding and buffering to a {@link VideoEncoder} implementation.
- * Currently uses {@link MjpegEncoder} (JPEG circular buffer + MJPEG upload).
- * Future: Vulkan H.264 encoder for on-device encoding.
- *
- * This class manages:
- * - AsyncFrameCapture coordination (PBO readback from GPU)
- * - Quality/config management
- * - Sensitive content detection
- * - Presigned URL fetching and upload orchestration
- * - Screenshot capture
+ * Prefers the GL PBO capture path, falling back to the CPU rasterizer when
+ * the GPU plugin is not active.
  */
 @Slf4j
 @Singleton
@@ -89,33 +80,24 @@ public class VideoRecorder
     private final OkHttpClient uploadClient;
     private final Gson gson;
 
-    // The active video encoder (MJPEG for now, Vulkan H.264 later)
     private final VideoEncoder encoder;
 
-    // Recording state
     private final AtomicBoolean isRecording = new AtomicBoolean(false);
     private final AtomicBoolean isCapturingPostEvent = new AtomicBoolean(false);
 
-    // Backpressure: limit concurrent encoding operations
     private final AtomicInteger pendingEncodes = new AtomicInteger(0);
     private static final int MAX_PENDING_ENCODES = 4;
 
-    // Sensitive content detection - cached to avoid expensive widget lookups every frame
     private final AtomicBoolean sensitiveContentVisible = new AtomicBoolean(false);
     private final AtomicLong lastSensitiveCheck = new AtomicLong(0);
     private static final long SENSITIVE_CHECK_INTERVAL_MS = 500;
 
     private AsyncFrameCapture asyncFrameCapture;
+    private SoftwareFrameCapture softwareFrameCapture;
 
-    // Track current capture settings to detect quality changes
     private volatile int currentCaptureFps = 0;
     private volatile float currentJpegQuality = 0.5f;
 
-    // Set when GPU plugin is detected as unavailable
-    private volatile boolean gpuUnavailable = false;
-    private volatile boolean gpuWarningShown = false;
-
-    // Default post-event duration in milliseconds
     private static final int DEFAULT_POST_EVENT_MS = 4000;
 
     @Inject
@@ -160,7 +142,6 @@ public class VideoRecorder
             return t;
         });
 
-        // Select the best available encoder (Vulkan H.264 if available, otherwise MJPEG)
         EncoderFallbackChain fallbackChain = new EncoderFallbackChain();
         this.encoder = fallbackChain.selectEncoder();
 
@@ -173,8 +154,6 @@ public class VideoRecorder
     {
         return "vulkan-h264".equals(encoder.encoderName());
     }
-
-    // ---- Package-private API for AsyncFrameCapture ----
 
     boolean isCurrentlyRecording()
     {
@@ -212,8 +191,6 @@ public class VideoRecorder
             }
         });
     }
-
-    // ---- Sensitive content detection ----
 
     private boolean isSensitiveContentVisible()
     {
@@ -264,17 +241,12 @@ public class VideoRecorder
         return sensitiveContentVisible.get();
     }
 
-    // ---- Recording lifecycle ----
-
     public void startRecording()
     {
         if (isRecording.getAndSet(true))
         {
             return;
         }
-
-        gpuUnavailable = false;
-        gpuWarningShown = false;
 
         VideoQuality quality = config.videoQuality();
         currentCaptureFps = quality.getFps() > 0 ? quality.getFps() : 30;
@@ -294,29 +266,39 @@ public class VideoRecorder
             return;
         }
 
-        if (asyncFrameCapture != null)
-        {
-            asyncFrameCapture.stop();
-            asyncFrameCapture = null;
-        }
-
+        stopCapturePipelines();
         encoder.stop();
         currentCaptureFps = 0;
     }
 
     private void onGpuUnavailable()
     {
-        log.debug("GPU plugin not active, falling back to screenshot-only");
-
         if (asyncFrameCapture != null)
         {
             asyncFrameCapture.stop();
             asyncFrameCapture = null;
         }
 
-        isRecording.set(false);
-        currentCaptureFps = 0;
-        gpuUnavailable = true;
+        if (softwareFrameCapture == null)
+        {
+            log.debug("GPU plugin not active, switching to CPU buffer capture");
+            softwareFrameCapture = new SoftwareFrameCapture(drawManager, client, this);
+            softwareFrameCapture.start();
+        }
+    }
+
+    private void stopCapturePipelines()
+    {
+        if (asyncFrameCapture != null)
+        {
+            asyncFrameCapture.stop();
+            asyncFrameCapture = null;
+        }
+        if (softwareFrameCapture != null)
+        {
+            softwareFrameCapture.stop();
+            softwareFrameCapture = null;
+        }
     }
 
     public void updateCaptureRateIfNeeded()
@@ -332,23 +314,11 @@ public class VideoRecorder
         {
             if (currentCaptureFps != 0)
             {
-                log.debug("Switching to Screenshot Only mode");
-
-                if (asyncFrameCapture != null)
-                {
-                    asyncFrameCapture.stop();
-                    asyncFrameCapture = null;
-                }
-
+                stopCapturePipelines();
                 encoder.stop();
                 currentCaptureFps = 0;
                 currentJpegQuality = 0;
             }
-            return;
-        }
-
-        if (gpuUnavailable)
-        {
             return;
         }
 
@@ -362,12 +332,10 @@ public class VideoRecorder
 
         if (targetFps != currentCaptureFps)
         {
-            log.debug("Capture rate changed from {} to {} FPS", currentCaptureFps, targetFps);
-
             encoder.reset();
             currentCaptureFps = targetFps;
 
-            if (asyncFrameCapture == null)
+            if (asyncFrameCapture == null && softwareFrameCapture == null)
             {
                 asyncFrameCapture = new AsyncFrameCapture(drawManager, this, this::onGpuUnavailable);
                 asyncFrameCapture.start();
@@ -377,7 +345,6 @@ public class VideoRecorder
         }
     }
 
-    // ---- Event capture ----
 
     public void captureEventVideo(VideoCallback callback)
     {
@@ -409,18 +376,6 @@ public class VideoRecorder
     {
         if (!isRecording.get())
         {
-            if (gpuUnavailable && !gpuWarningShown)
-            {
-                gpuWarningShown = true;
-                if (chatMessageManager != null)
-                {
-                    chatMessageManager.queue(QueuedMessage.builder()
-                        .type(ChatMessageType.GAMEMESSAGE)
-                        .runeLiteFormattedMessage("<col=ff9040>[OSRS Tracker] GPU plugin required for video. Using screenshot-only mode.</col>")
-                        .build());
-                }
-            }
-
             if (onEncodingStart != null)
             {
                 onEncodingStart.run();
@@ -501,8 +456,6 @@ public class VideoRecorder
             });
         });
     }
-
-    // ---- Finalize and upload ----
 
     private void finalizeCapture(VideoCallback callback, long videoStartTime, long videoEndTime,
                                  EventKind kind, String description)
@@ -638,9 +591,6 @@ public class VideoRecorder
         return candidate;
     }
 
-    /**
-     * Uploads clip data to Backblaze using streaming to avoid memory spikes.
-     */
     private boolean uploadClipToBackblaze(String uploadUrl, VideoEncoder.ClipData clipData)
     {
         try
@@ -703,8 +653,6 @@ public class VideoRecorder
             return false;
         }
     }
-
-    // ---- Presigned URL ----
 
     private static class PresignedUrlResponse
     {
@@ -774,8 +722,6 @@ public class VideoRecorder
             return null;
         }
     }
-
-    // ---- Screenshot blur (kept here since it's only for screenshots, not video frames) ----
 
     private BufferedImage applyScreenshotBlur(BufferedImage image)
     {
@@ -856,8 +802,6 @@ public class VideoRecorder
         return output;
     }
 
-    // ---- Utilities ----
-
     private String imageToBase64(BufferedImage image) throws IOException
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -880,9 +824,6 @@ public class VideoRecorder
             .build());
     }
 
-    /**
-     * Callback interface for video capture completion.
-     */
     public interface VideoCallback
     {
         void onComplete(String screenshotBase64, String videoKey);

--- a/src/main/java/com/osrstracker/video/VideoRecorder.java
+++ b/src/main/java/com/osrstracker/video/VideoRecorder.java
@@ -45,6 +45,9 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -164,6 +167,11 @@ public class VideoRecorder
         log.debug("Video recorder initialized (encoder={}, fallback={})",
             encoder.encoderName(),
             fallbackChain.getFallbackReason() != null ? fallbackChain.getFallbackReason() : "none");
+    }
+
+    public boolean isVulkanEncoderActive()
+    {
+        return "vulkan-h264".equals(encoder.encoderName());
     }
 
     // ---- Package-private API for AsyncFrameCapture ----
@@ -373,15 +381,31 @@ public class VideoRecorder
 
     public void captureEventVideo(VideoCallback callback)
     {
-        captureEventVideo(callback, null, DEFAULT_POST_EVENT_MS);
+        captureEventVideo(callback, null, DEFAULT_POST_EVENT_MS, EventKind.GENERIC, null);
     }
 
     public void captureEventVideo(VideoCallback callback, Runnable onEncodingStart)
     {
-        captureEventVideo(callback, onEncodingStart, DEFAULT_POST_EVENT_MS);
+        captureEventVideo(callback, onEncodingStart, DEFAULT_POST_EVENT_MS, EventKind.GENERIC, null);
+    }
+
+    public void captureEventVideo(VideoCallback callback, EventKind kind, String description)
+    {
+        captureEventVideo(callback, null, DEFAULT_POST_EVENT_MS, kind, description);
+    }
+
+    public void captureEventVideo(VideoCallback callback, Runnable onEncodingStart, EventKind kind, String description)
+    {
+        captureEventVideo(callback, onEncodingStart, DEFAULT_POST_EVENT_MS, kind, description);
     }
 
     public void captureEventVideo(VideoCallback callback, Runnable onEncodingStart, int postEventMs)
+    {
+        captureEventVideo(callback, onEncodingStart, postEventMs, EventKind.GENERIC, null);
+    }
+
+    public void captureEventVideo(VideoCallback callback, Runnable onEncodingStart, int postEventMs,
+                                  EventKind kind, String description)
     {
         if (!isRecording.get())
         {
@@ -447,7 +471,7 @@ public class VideoRecorder
             {
                 onEncodingStart.run();
             }
-            finalizeCapture(callback, videoStartTime, videoEndTime);
+            finalizeCapture(callback, videoStartTime, videoEndTime, kind, description);
         }, finalPostEventMs, TimeUnit.MILLISECONDS);
     }
 
@@ -480,7 +504,8 @@ public class VideoRecorder
 
     // ---- Finalize and upload ----
 
-    private void finalizeCapture(VideoCallback callback, long videoStartTime, long videoEndTime)
+    private void finalizeCapture(VideoCallback callback, long videoStartTime, long videoEndTime,
+                                 EventKind kind, String description)
     {
         final boolean shouldBlur = isSensitiveContentVisible();
 
@@ -499,10 +524,23 @@ public class VideoRecorder
 
                     final int fps = config.videoQuality().getFps();
 
-                    // Delegate clip extraction to the encoder
+                    long drainDeadline = System.currentTimeMillis() + 1500;
+                    while (pendingEncodes.get() > 0 && System.currentTimeMillis() < drainDeadline)
+                    {
+                        try { Thread.sleep(10); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); break; }
+                    }
+
                     VideoEncoder.ClipData clipData = encoder.finalizeClip(videoStartTime, videoEndTime);
 
                     if (clipData == null || clipData.getFrames().isEmpty())
+                    {
+                        callback.onComplete(screenshotBase64, null);
+                        return;
+                    }
+
+                    saveClipLocally(clipData, kind, description);
+
+                    if (config.apiToken().isEmpty() || !config.uploadToPlatform())
                     {
                         callback.onComplete(screenshotBase64, null);
                         return;
@@ -553,6 +591,51 @@ public class VideoRecorder
                 }
             });
         });
+    }
+
+    private void saveClipLocally(VideoEncoder.ClipData clipData, EventKind kind, String description)
+    {
+        if (!"video/mp4".equals(clipData.getContentType()))
+        {
+            return;
+        }
+
+        Path root = Paths.get(System.getProperty("user.home"), ".runelite", "osrs-tracker-clips");
+        Path target = kind.subfolder().isEmpty() ? root : root.resolve(kind.subfolder());
+        String slug = slugify(description);
+        if (slug.isEmpty())
+        {
+            slug = "clip_" + System.currentTimeMillis();
+        }
+
+        try
+        {
+            Files.createDirectories(target);
+            Path out = uniquePath(target, slug);
+            Files.write(out, clipData.getFrames().get(0));
+        }
+        catch (Exception e)
+        {
+            log.warn("Failed to save clip to {}", target, e);
+        }
+    }
+
+    private static String slugify(String input)
+    {
+        if (input == null) return "";
+        String cleaned = input.trim().toLowerCase().replaceAll("[^a-z0-9]+", "_");
+        cleaned = cleaned.replaceAll("^_+|_+$", "");
+        return cleaned.length() > 80 ? cleaned.substring(0, 80) : cleaned;
+    }
+
+    private static Path uniquePath(Path dir, String slug)
+    {
+        Path candidate = dir.resolve(slug + ".mp4");
+        for (int i = 2; Files.exists(candidate); i++)
+        {
+            candidate = dir.resolve(slug + "_" + i + ".mp4");
+        }
+        return candidate;
     }
 
     /**

--- a/src/main/java/com/osrstracker/video/encode/AnnexBWriter.java
+++ b/src/main/java/com/osrstracker/video/encode/AnnexBWriter.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * H.264 Annex B wire-format writer. Pure Java, no Vulkan imports, no GPU required.
+ *
+ * Vulkan Video Encode writes raw NAL unit bodies into the bitstream buffer WITHOUT
+ * Annex B start codes. For an elementary stream (`.h264`) or Annex B-in-MP4, the host
+ * must prepend `0x00 0x00 0x00 0x01` before each NAL and emit SPS+PPS before every IDR
+ * access unit (so decoders joining mid-stream can initialize).
+ */
+public final class AnnexBWriter
+{
+    static final byte[] START_CODE = { 0x00, 0x00, 0x00, 0x01 };
+
+    public static final int NAL_TYPE_NON_IDR_SLICE = 1;
+    public static final int NAL_TYPE_IDR_SLICE     = 5;
+    public static final int NAL_TYPE_SEI           = 6;
+    public static final int NAL_TYPE_SPS           = 7;
+    public static final int NAL_TYPE_PPS           = 8;
+    public static final int NAL_TYPE_AUD           = 9;
+
+    private AnnexBWriter() {}
+
+    /**
+     * Write one NAL unit: start code followed by the raw NAL body from the encoder.
+     * The body must already contain the NAL header byte and any emulation-prevention
+     * bytes the driver inserted; do not strip or re-encode.
+     *
+     * Position of {@code nalBody} is preserved (a duplicate is used internally).
+     */
+    public static void writeNalu(OutputStream out, ByteBuffer nalBody) throws IOException
+    {
+        Objects.requireNonNull(out, "out");
+        Objects.requireNonNull(nalBody, "nalBody");
+        if (!nalBody.hasRemaining())
+        {
+            return;
+        }
+        out.write(START_CODE);
+        ByteBuffer view = nalBody.duplicate();
+        if (view.hasArray())
+        {
+            out.write(view.array(), view.arrayOffset() + view.position(), view.remaining());
+        }
+        else
+        {
+            byte[] tmp = new byte[view.remaining()];
+            view.get(tmp);
+            out.write(tmp);
+        }
+    }
+
+    /**
+     * Write an IDR access unit: SPS, then PPS, then the IDR slice NAL body.
+     * Each is wrapped with its own start code. Call this once per IDR frame.
+     *
+     * All three buffers must contain NAL bodies as returned by the driver / by
+     * {@code vkGetEncodedVideoSessionParametersKHR} (no start codes, emulation-prevention
+     * bytes already inserted).
+     */
+    public static void writeIdrAccessUnit(OutputStream out, ByteBuffer sps, ByteBuffer pps, ByteBuffer idrSlice)
+        throws IOException
+    {
+        writeNalu(out, sps);
+        writeNalu(out, pps);
+        writeNalu(out, idrSlice);
+    }
+
+    /**
+     * Return the {@code nal_unit_type} (bits 0-4 of the first byte) of a NAL body.
+     * Throws IllegalArgumentException if the body is empty or has the forbidden zero
+     * bit set.
+     */
+    public static int readNalUnitType(ByteBuffer nalBody)
+    {
+        Objects.requireNonNull(nalBody, "nalBody");
+        if (!nalBody.hasRemaining())
+        {
+            throw new IllegalArgumentException("empty NAL body");
+        }
+        int header = nalBody.get(nalBody.position()) & 0xFF;
+        if ((header & 0x80) != 0)
+        {
+            throw new IllegalArgumentException("forbidden_zero_bit set in NAL header: 0x" + Integer.toHexString(header));
+        }
+        return header & 0x1F;
+    }
+
+    /**
+     * Iterate NAL units in an Annex B byte stream, returning each NAL body as a
+     * slice of the original array (no copy). Start codes ({@code 0x000001} or
+     * {@code 0x00000001}) separate units; the body excludes the start code.
+     *
+     * Returns a record for each NAL with {@code offset} and {@code length} into
+     * {@code data}, in stream order.
+     */
+    public static java.util.List<Nalu> splitNalus(byte[] data)
+    {
+        Objects.requireNonNull(data, "data");
+        java.util.ArrayList<Nalu> out = new java.util.ArrayList<>();
+        int n = data.length;
+        int i = 0;
+        int bodyStart = -1;
+
+        while (i < n)
+        {
+            int scLen = matchStartCode(data, i, n);
+            if (scLen > 0)
+            {
+                if (bodyStart >= 0)
+                {
+                    out.add(new Nalu(bodyStart, i - bodyStart));
+                }
+                i += scLen;
+                bodyStart = i;
+            }
+            else
+            {
+                i++;
+            }
+        }
+        if (bodyStart >= 0 && bodyStart < n)
+        {
+            out.add(new Nalu(bodyStart, n - bodyStart));
+        }
+        return out;
+    }
+
+    private static int matchStartCode(byte[] data, int i, int n)
+    {
+        if (i + 4 <= n && data[i] == 0 && data[i + 1] == 0 && data[i + 2] == 0 && data[i + 3] == 1)
+        {
+            return 4;
+        }
+        if (i + 3 <= n && data[i] == 0 && data[i + 1] == 0 && data[i + 2] == 1)
+        {
+            return 3;
+        }
+        return 0;
+    }
+
+    /** A NAL unit body as a slice of a backing Annex B byte array. */
+    public static final class Nalu
+    {
+        public final int offset;
+        public final int length;
+
+        public Nalu(int offset, int length)
+        {
+            this.offset = offset;
+            this.length = length;
+        }
+
+        public int nalUnitType(byte[] data)
+        {
+            int header = data[offset] & 0xFF;
+            if ((header & 0x80) != 0)
+            {
+                throw new IllegalArgumentException("forbidden_zero_bit set");
+            }
+            return header & 0x1F;
+        }
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/Disposables.java
+++ b/src/main/java/com/osrstracker/video/encode/Disposables.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * LIFO-ordered cleanup stack. Register destroy actions in creation
+ * order; {@link #close()} pops and runs them in reverse, which is what
+ * the Vulkan spec requires (children before parents). Exceptions from
+ * individual destroy actions are collected and rethrown so one bad
+ * handle doesn't skip the rest.
+ */
+final class Disposables implements AutoCloseable
+{
+    private final Deque<Runnable> stack = new ArrayDeque<>();
+
+    void add(Runnable destroy)
+    {
+        stack.push(destroy);
+    }
+
+    @Override
+    public void close()
+    {
+        Throwable first = null;
+        while (!stack.isEmpty())
+        {
+            try
+            {
+                stack.pop().run();
+            }
+            catch (Throwable t)
+            {
+                if (first == null) first = t;
+                else first.addSuppressed(t);
+            }
+        }
+        if (first instanceof RuntimeException) throw (RuntimeException) first;
+        if (first instanceof Error) throw (Error) first;
+        if (first != null) throw new RuntimeException(first);
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/EncodeResources.java
+++ b/src/main/java/com/osrstracker/video/encode/EncodeResources.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.*;
+
+import java.nio.LongBuffer;
+
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.vulkan.KHRVideoEncodeQueue.*;
+import static org.lwjgl.vulkan.KHRVideoQueue.*;
+import static org.lwjgl.vulkan.VK10.*;
+
+/**
+ * Per-clip GPU resources: the NV12 input image, layered DPB image,
+ * bitstream and staging buffers with host-mapped pointers, and the
+ * encode-feedback query pool. Constructor allocates everything up
+ * front; {@link #close()} tears down in Vulkan teardown order (views
+ * before images, buffers before their memory).
+ *
+ * Handles are package-visible fields because the encode recorder reads
+ * them every frame. Boxing them behind getters would add noise without
+ * hiding anything, since everything in this package is one logical unit.
+ */
+final class EncodeResources implements AutoCloseable
+{
+    static final int BITSTREAM_BUFFER_SIZE = 4 * 1024 * 1024;
+    /** Depth of the encode ring. Frame N+RING_DEPTH reuses slot N's resources. */
+    static final int RING_DEPTH = 2;
+
+    private final VulkanDevice vulkanDevice;
+    private final VulkanCapabilities caps;
+    private final Disposables disposables = new Disposables();
+
+    final long[] encodeInputImage = new long[RING_DEPTH];
+    final long[] encodeInputImageView = new long[RING_DEPTH];
+    final long[] encodeInputMemory = new long[RING_DEPTH];
+
+    long dpbImage = VK_NULL_HANDLE;
+    /** Both entries alias the same layered 2D_ARRAY view; per-slot selection is done via baseArrayLayer. */
+    final long[] dpbImageViews = new long[2];
+    long dpbMemory = VK_NULL_HANDLE;
+
+    final long[] bitstreamBuffer = new long[RING_DEPTH];
+    final long[] bitstreamMemory = new long[RING_DEPTH];
+    final long[] bitstreamMappedPtr = new long[RING_DEPTH];
+
+    final long[] stagingBuffer = new long[RING_DEPTH];
+    final long[] stagingMemory = new long[RING_DEPTH];
+    final long[] stagingMappedPtr = new long[RING_DEPTH];
+
+    /** Single pool with {@link #RING_DEPTH} queries, one per ring slot. */
+    long feedbackQueryPool = VK_NULL_HANDLE;
+
+    EncodeResources(VulkanDevice vulkanDevice, VulkanCapabilities caps,
+                    int paddedWidth, int paddedHeight)
+    {
+        this.vulkanDevice = vulkanDevice;
+        this.caps = caps;
+        try
+        {
+            for (int i = 0; i < RING_DEPTH; i++)
+            {
+                createEncodeInputImage(i, paddedWidth, paddedHeight);
+                createBitstreamBuffer(i);
+                createStagingBuffer(i, paddedWidth, paddedHeight);
+            }
+            createDpbImages(paddedWidth, paddedHeight);
+            createFeedbackQueryPool();
+        }
+        catch (Throwable t)
+        {
+            disposables.close();
+            throw t;
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        disposables.close();
+    }
+
+    private void createEncodeInputImage(int slot, int width, int height)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+
+        try (MemoryStack stack = stackPush())
+        {
+            VkVideoProfileListInfoKHR profileList = VkVideoProfileListInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR)
+                .pProfiles(VkVideoProfileInfoKHR.calloc(1, stack).put(0, caps.buildVideoProfile(stack)));
+
+            VkImageCreateInfo imageInfo = VkImageCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
+                .pNext(profileList.address())
+                .imageType(VK_IMAGE_TYPE_2D)
+                .format(caps.getPictureFormat())
+                .extent(e -> e.set(width, height, 1))
+                .mipLevels(1)
+                .arrayLayers(1)
+                .samples(VK_SAMPLE_COUNT_1_BIT)
+                .tiling(VK_IMAGE_TILING_OPTIMAL)
+                .usage(VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR | VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+                .sharingMode(VK_SHARING_MODE_EXCLUSIVE)
+                .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
+
+            LongBuffer pImage = stack.mallocLong(1);
+            int result = vkCreateImage(device, imageInfo, null, pImage);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateImage (encode input slot " + slot + ") failed: " + result);
+            }
+            encodeInputImage[slot] = pImage.get(0);
+            final int slotF = slot;
+
+            encodeInputMemory[slot] = allocateAndBindImageMemory(device, encodeInputImage[slot],
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, stack);
+            // Register in Vulkan-teardown order (memory last, image, view top of stack)
+            // so pop order is view -> image -> free-memory.
+            disposables.add(() -> vkFreeMemory(device, encodeInputMemory[slotF], null));
+            disposables.add(() -> vkDestroyImage(device, encodeInputImage[slotF], null));
+
+            VkImageViewCreateInfo viewInfo = VkImageViewCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
+                .image(encodeInputImage[slot])
+                .viewType(VK_IMAGE_VIEW_TYPE_2D)
+                .format(caps.getPictureFormat())
+                .subresourceRange(r -> r
+                    .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
+                    .baseMipLevel(0)
+                    .levelCount(1)
+                    .baseArrayLayer(0)
+                    .layerCount(1));
+
+            LongBuffer pView = stack.mallocLong(1);
+            result = vkCreateImageView(device, viewInfo, null, pView);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateImageView (encode input slot " + slot + ") failed: " + result);
+            }
+            encodeInputImageView[slot] = pView.get(0);
+            disposables.add(() -> vkDestroyImageView(device, encodeInputImageView[slotF], null));
+        }
+    }
+
+    private void createDpbImages(int width, int height)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+
+        try (MemoryStack stack = stackPush())
+        {
+            VkVideoProfileListInfoKHR profileList = VkVideoProfileListInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR)
+                .pProfiles(VkVideoProfileInfoKHR.calloc(1, stack).put(0, caps.buildVideoProfile(stack)));
+
+            VkImageCreateInfo imageInfo = VkImageCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
+                .pNext(profileList.address())
+                .imageType(VK_IMAGE_TYPE_2D)
+                .format(caps.getPictureFormat())
+                .extent(e -> e.set(width, height, 1))
+                .mipLevels(1)
+                .arrayLayers(2)
+                .samples(VK_SAMPLE_COUNT_1_BIT)
+                .tiling(VK_IMAGE_TILING_OPTIMAL)
+                .usage(VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR)
+                .sharingMode(VK_SHARING_MODE_EXCLUSIVE)
+                .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
+
+            LongBuffer pImage = stack.mallocLong(1);
+            int result = vkCreateImage(device, imageInfo, null, pImage);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateImage (DPB) failed: " + result);
+            }
+            dpbImage = pImage.get(0);
+
+            dpbMemory = allocateAndBindImageMemory(device, dpbImage,
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, stack);
+            disposables.add(() -> vkFreeMemory(device, dpbMemory, null));
+            disposables.add(() -> vkDestroyImage(device, dpbImage, null));
+
+            // A single layered 2D_ARRAY view covers both DPB slots; per-slot
+            // selection happens via baseArrayLayer on the picture resource.
+            // Separate per-slot views confuse VCN's cross-submission DPB
+            // tracking and silently break inter-prediction.
+            VkImageViewCreateInfo viewInfo = VkImageViewCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
+                .image(dpbImage)
+                .viewType(VK_IMAGE_VIEW_TYPE_2D_ARRAY)
+                .format(caps.getPictureFormat())
+                .subresourceRange(r -> r
+                    .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
+                    .baseMipLevel(0)
+                    .levelCount(1)
+                    .baseArrayLayer(0)
+                    .layerCount(2));
+
+            LongBuffer pView = stack.mallocLong(1);
+            result = vkCreateImageView(device, viewInfo, null, pView);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateImageView (DPB layered) failed: " + result);
+            }
+            dpbImageViews[0] = dpbImageViews[1] = pView.get(0);
+            disposables.add(() -> vkDestroyImageView(device, dpbImageViews[0], null));
+        }
+    }
+
+    private void createBitstreamBuffer(int slot)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+        final int slotF = slot;
+
+        try (MemoryStack stack = stackPush())
+        {
+            VkVideoProfileListInfoKHR profileList = VkVideoProfileListInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR)
+                .pProfiles(VkVideoProfileInfoKHR.calloc(1, stack).put(0, caps.buildVideoProfile(stack)));
+
+            VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO)
+                .pNext(profileList.address())
+                .size(BITSTREAM_BUFFER_SIZE)
+                .usage(VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR)
+                .sharingMode(VK_SHARING_MODE_EXCLUSIVE);
+
+            LongBuffer pBuffer = stack.mallocLong(1);
+            int result = vkCreateBuffer(device, bufferInfo, null, pBuffer);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateBuffer (bitstream slot " + slot + ") failed: " + result);
+            }
+            bitstreamBuffer[slot] = pBuffer.get(0);
+
+            bitstreamMemory[slot] = allocateAndBindBufferMemory(device, bitstreamBuffer[slot],
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, stack);
+            disposables.add(() -> vkFreeMemory(device, bitstreamMemory[slotF], null));
+            disposables.add(() -> vkDestroyBuffer(device, bitstreamBuffer[slotF], null));
+
+            PointerBuffer pData = stack.mallocPointer(1);
+            result = vkMapMemory(device, bitstreamMemory[slot], 0, BITSTREAM_BUFFER_SIZE, 0, pData);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkMapMemory (bitstream slot " + slot + ") failed: " + result);
+            }
+            bitstreamMappedPtr[slot] = pData.get(0);
+            disposables.add(() -> vkUnmapMemory(device, bitstreamMemory[slotF]));
+        }
+    }
+
+    private void createStagingBuffer(int slot, int width, int height)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+        final int slotF = slot;
+        // NV12: Y plane (W*H bytes) + interleaved UV plane (W*H/2 bytes) = W*H*3/2.
+        long bufferSize = (long) width * height * 3 / 2;
+
+        try (MemoryStack stack = stackPush())
+        {
+            VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO)
+                .size(bufferSize)
+                .usage(VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
+                .sharingMode(VK_SHARING_MODE_EXCLUSIVE);
+
+            LongBuffer pBuffer = stack.mallocLong(1);
+            int result = vkCreateBuffer(device, bufferInfo, null, pBuffer);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateBuffer (staging slot " + slot + ") failed: " + result);
+            }
+            stagingBuffer[slot] = pBuffer.get(0);
+
+            stagingMemory[slot] = allocateAndBindBufferMemory(device, stagingBuffer[slot],
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stack);
+            disposables.add(() -> vkFreeMemory(device, stagingMemory[slotF], null));
+            disposables.add(() -> vkDestroyBuffer(device, stagingBuffer[slotF], null));
+
+            PointerBuffer pData = stack.mallocPointer(1);
+            result = vkMapMemory(device, stagingMemory[slot], 0, bufferSize, 0, pData);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkMapMemory (staging slot " + slot + ") failed: " + result);
+            }
+            stagingMappedPtr[slot] = pData.get(0);
+            disposables.add(() -> vkUnmapMemory(device, stagingMemory[slotF]));
+        }
+    }
+
+    /**
+     * Profile chain on the pool matches the session's profile (VUID-07130 / VUID-07133).
+     * Every encode wraps the commands with vkCmdBeginQuery/EndQuery; some VCN
+     * driver paths need that wrapping to enable real rate-controlled emit mode.
+     */
+    private void createFeedbackQueryPool()
+    {
+        VkDevice device = vulkanDevice.getDevice();
+        try (MemoryStack stack = stackPush())
+        {
+            VkVideoProfileInfoKHR profile = caps.buildVideoProfile(stack);
+
+            VkQueryPoolVideoEncodeFeedbackCreateInfoKHR feedbackInfo =
+                VkQueryPoolVideoEncodeFeedbackCreateInfoKHR.calloc(stack)
+                    .sType(VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR)
+                    .pNext(profile.address())
+                    .encodeFeedbackFlags(
+                        VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR
+                            | VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR);
+
+            VkQueryPoolCreateInfo poolInfo = VkQueryPoolCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO)
+                .pNext(feedbackInfo.address())
+                .queryType(VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR)
+                .queryCount(RING_DEPTH);
+
+            LongBuffer pPool = stack.mallocLong(1);
+            int result = vkCreateQueryPool(device, poolInfo, null, pPool);
+            if (result != VK_SUCCESS)
+            {
+                throw new RuntimeException("vkCreateQueryPool (encode feedback) failed: " + result);
+            }
+            feedbackQueryPool = pPool.get(0);
+            disposables.add(() -> vkDestroyQueryPool(device, feedbackQueryPool, null));
+        }
+    }
+
+    private long allocateAndBindImageMemory(VkDevice device, long image, int properties, MemoryStack stack)
+    {
+        VkMemoryRequirements memReqs = VkMemoryRequirements.calloc(stack);
+        vkGetImageMemoryRequirements(device, image, memReqs);
+
+        VkMemoryAllocateInfo allocInfo = VkMemoryAllocateInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
+            .allocationSize(memReqs.size())
+            .memoryTypeIndex(findMemoryType(memReqs.memoryTypeBits(), properties, stack));
+
+        LongBuffer pMemory = stack.mallocLong(1);
+        int result = vkAllocateMemory(device, allocInfo, null, pMemory);
+        if (result != VK_SUCCESS)
+        {
+            throw new RuntimeException("vkAllocateMemory failed: " + result);
+        }
+        long memory = pMemory.get(0);
+        vkBindImageMemory(device, image, memory, 0);
+        return memory;
+    }
+
+    private long allocateAndBindBufferMemory(VkDevice device, long buffer, int properties, MemoryStack stack)
+    {
+        VkMemoryRequirements memReqs = VkMemoryRequirements.calloc(stack);
+        vkGetBufferMemoryRequirements(device, buffer, memReqs);
+
+        int memTypeIdx;
+        try
+        {
+            memTypeIdx = findMemoryType(memReqs.memoryTypeBits(), properties, stack);
+        }
+        catch (RuntimeException e)
+        {
+            memTypeIdx = findMemoryType(memReqs.memoryTypeBits(),
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, stack);
+        }
+
+        VkMemoryAllocateInfo allocInfo = VkMemoryAllocateInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
+            .allocationSize(memReqs.size())
+            .memoryTypeIndex(memTypeIdx);
+
+        LongBuffer pMemory = stack.mallocLong(1);
+        int result = vkAllocateMemory(device, allocInfo, null, pMemory);
+        if (result != VK_SUCCESS)
+        {
+            throw new RuntimeException("vkAllocateMemory failed: " + result);
+        }
+        long memory = pMemory.get(0);
+        vkBindBufferMemory(device, buffer, memory, 0);
+        return memory;
+    }
+
+    private int findMemoryType(int typeFilter, int properties, MemoryStack stack)
+    {
+        VkPhysicalDeviceMemoryProperties memProps = VkPhysicalDeviceMemoryProperties.calloc(stack);
+        vkGetPhysicalDeviceMemoryProperties(vulkanDevice.getPhysicalDevice(), memProps);
+
+        for (int i = 0; i < memProps.memoryTypeCount(); i++)
+        {
+            if ((typeFilter & (1 << i)) != 0 &&
+                (memProps.memoryTypes(i).propertyFlags() & properties) == properties)
+            {
+                return i;
+            }
+        }
+
+        for (int i = 0; i < memProps.memoryTypeCount(); i++)
+        {
+            if ((typeFilter & (1 << i)) != 0)
+            {
+                return i;
+            }
+        }
+
+        throw new RuntimeException("Failed to find suitable memory type");
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/EncoderFallbackChain.java
+++ b/src/main/java/com/osrstracker/video/encode/EncoderFallbackChain.java
@@ -49,7 +49,7 @@ public class EncoderFallbackChain
         if (os.contains("mac"))
         {
             fallbackReason = "macOS (MoltenVK does not support Vulkan Video)";
-            log.debug("Encoder fallback: {}", fallbackReason);
+            log.info("Encoder fallback: {}", fallbackReason);
             return new MjpegEncoder();
         }
 
@@ -61,7 +61,7 @@ public class EncoderFallbackChain
         catch (ClassNotFoundException e)
         {
             fallbackReason = "LWJGL Vulkan not on classpath";
-            log.debug("Encoder fallback: {}", fallbackReason);
+            log.info("Encoder fallback: {}", fallbackReason);
             return new MjpegEncoder();
         }
 
@@ -79,7 +79,7 @@ public class EncoderFallbackChain
             {
                 vulkanDevice.close();
                 fallbackReason = "GPU does not support H.264 Vulkan Video Encode";
-                log.debug("Encoder fallback: {}", fallbackReason);
+                log.info("Encoder fallback: {}", fallbackReason);
                 return new MjpegEncoder();
             }
 
@@ -102,7 +102,7 @@ public class EncoderFallbackChain
                 catch (Exception ignored) {}
             }
             fallbackReason = "Vulkan init failed: " + e.getMessage();
-            log.debug("Encoder fallback: {}", fallbackReason);
+            log.info("Encoder fallback: {}", fallbackReason);
             return new MjpegEncoder();
         }
     }

--- a/src/main/java/com/osrstracker/video/encode/FrameEncoder.java
+++ b/src/main/java/com/osrstracker/video/encode/FrameEncoder.java
@@ -1,0 +1,880 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import lombok.extern.slf4j.Slf4j;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.*;
+import org.lwjgl.vulkan.video.StdVideoEncodeH264PictureInfo;
+import org.lwjgl.vulkan.video.StdVideoEncodeH264PictureInfoFlags;
+import org.lwjgl.vulkan.video.StdVideoEncodeH264ReferenceInfo;
+import org.lwjgl.vulkan.video.StdVideoEncodeH264ReferenceListsInfo;
+import org.lwjgl.vulkan.video.StdVideoEncodeH264SliceHeader;
+
+import java.awt.image.BufferedImage;
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.system.MemoryUtil.memByteBuffer;
+import static org.lwjgl.vulkan.KHRVideoEncodeH264.*;
+import static org.lwjgl.vulkan.KHRVideoEncodeQueue.*;
+import static org.lwjgl.vulkan.KHRVideoQueue.*;
+import static org.lwjgl.vulkan.VK10.*;
+import static org.lwjgl.vulkan.VK13.*;
+import static org.lwjgl.vulkan.video.STDVulkanVideoCodecH264.*;
+
+/**
+ * Ring-pipelined H.264 frame encoder. CPU staging of frame N+1 overlaps with
+ * GPU encode of frame N via a {@link EncodeResources#RING_DEPTH}-deep slot
+ * ring; {@link #encodeFrame} submits into slot {@code frameIndex % RING_DEPTH}
+ * and returns the slot's previous tenant, or {@code null} until the ring
+ * fills. Caller must {@link #drainRemaining} after the last submit.
+ *
+ * DPB slot rotation (mod 2) is independent of ring slot rotation; the index
+ * collision is coincidence. DPB tracks reconstructed pictures for inter-
+ * prediction, the ring tracks per-frame scratch.
+ *
+ * One instance is valid for a single padded (w,h,fps). Dimension changes
+ * rebuild this and {@link EncodeResources}.
+ */
+@Slf4j
+final class FrameEncoder
+{
+    private static final long FENCE_TIMEOUT_NS = 5_000_000_000L;
+
+    private static final long VBR_AVERAGE_BITRATE_BPS       = 10_000_000L;
+    // Peak 1.5x avg. With max==avg, VBR degenerates to CBR.
+    private static final long VBR_MAX_BITRATE_BPS           = 15_000_000L;
+    private static final int  VBR_VIRTUAL_BUFFER_MS         = 2000;
+    private static final int  VBR_INITIAL_VIRTUAL_BUFFER_MS = 1000;
+
+    private final VulkanDevice vulkanDevice;
+    private final VulkanCapabilities caps;
+    private final H264SessionConfig sessionConfig;
+    private final EncodeResources resources;
+    private final VkCommandBuffer[] commandBuffers;
+    private final VkCommandBuffer[] gfxCommandBuffers;
+    private final long[] encodeFences;
+    private final long[] uploadSemaphores;
+    private final int encodedWidth;
+    private final int encodedHeight;
+    private final int fps;
+
+    /** Reused across frames. Right/bottom padding is never written and stays
+     *  at the zero initialiser; hidden by SPS frame_cropping at decode. */
+    private final int[] paddedPixels;
+
+    /** frameIndex in-flight per slot, or -1 if the slot is free. */
+    private final int[] pendingFrame = new int[EncodeResources.RING_DEPTH];
+    /** Set when the slot's last submit was an orphan drain (no encode cb).
+     *  Tells drainSlot to skip the bitstream query; its result is stale. */
+    private final boolean[] slotFailed = new boolean[EncodeResources.RING_DEPTH];
+
+    FrameEncoder(VulkanDevice vulkanDevice, VulkanCapabilities caps,
+                 H264SessionConfig sessionConfig, EncodeResources resources,
+                 VkCommandBuffer[] commandBuffers, VkCommandBuffer[] gfxCommandBuffers,
+                 long[] encodeFences, long[] uploadSemaphores,
+                 int encodedWidth, int encodedHeight, int fps)
+    {
+        this.vulkanDevice = vulkanDevice;
+        this.caps = caps;
+        this.sessionConfig = sessionConfig;
+        this.resources = resources;
+        this.commandBuffers = commandBuffers;
+        this.gfxCommandBuffers = gfxCommandBuffers;
+        this.encodeFences = encodeFences;
+        this.uploadSemaphores = uploadSemaphores;
+        this.encodedWidth = encodedWidth;
+        this.encodedHeight = encodedHeight;
+        this.fps = fps;
+        this.paddedPixels = new int[encodedWidth * encodedHeight];
+        Arrays.fill(pendingFrame, -1);
+    }
+
+    /**
+     * Submits frame {@code frameIndex} into its ring slot; returns the
+     * previously-occupying frame's bitstream, or {@code null} for the first
+     * {@link EncodeResources#RING_DEPTH} calls. Call {@link #drainRemaining}
+     * after the last frame to collect the tail.
+     */
+    byte[] encodeFrame(BufferedImage frame, int width, int height,
+                       boolean isIdr, int frameIndex)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+        int ringSlot = frameIndex % EncodeResources.RING_DEPTH;
+
+        byte[] prev = null;
+        if (pendingFrame[ringSlot] != -1)
+        {
+            prev = drainSlot(ringSlot);
+        }
+
+        int yBytes = encodedWidth * encodedHeight;
+        stageNv12Frame(frame, width, height, yBytes, ringSlot);
+
+        try (MemoryStack stack = stackPush())
+        {
+            if (!resetSlotSync(device, ringSlot)) return prev;
+            if (!recordAndSubmitUpload(stack, yBytes, ringSlot, frameIndex)) return prev;
+
+            int dpbSlot = frameIndex % 2;
+            int refSlot = (frameIndex + 1) % 2;
+            if (!recordAndSubmitEncode(stack, isIdr, dpbSlot, refSlot, frameIndex, ringSlot))
+            {
+                orphanDrainSlot(stack, ringSlot, frameIndex);
+                return prev;
+            }
+            pendingFrame[ringSlot] = frameIndex;
+        }
+        return prev;
+    }
+
+    /**
+     * Consumes a stranded {@code uploadSemaphores[slot]} signal when encode
+     * submit fails after the graphics upload is already queued. Without this,
+     * the next reuse would signal-an-already-signaled semaphore (spec UB).
+     */
+    private void orphanDrainSlot(MemoryStack stack, int ringSlot, int frameIndex)
+    {
+        log.warn("encode submit failed for frame {}, draining slot {}", frameIndex, ringSlot);
+        VkSemaphoreSubmitInfo.Buffer waitInfo = VkSemaphoreSubmitInfo.calloc(1, stack)
+            .sType$Default()
+            .semaphore(uploadSemaphores[ringSlot])
+            .stageMask(VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+        VkSubmitInfo2.Buffer drain = VkSubmitInfo2.calloc(1, stack)
+            .sType$Default()
+            .pWaitSemaphoreInfos(waitInfo);
+        int r = vkQueueSubmit2(vulkanDevice.getVideoEncodeQueue(), drain, encodeFences[ringSlot]);
+        if (r != VK_SUCCESS)
+        {
+            // Likely device-lost. Clear state; burstEncode's catch falls back to MJPEG.
+            log.error("orphan drain submit slot {} failed: {}; slot left empty", ringSlot, r);
+            slotFailed[ringSlot] = false;
+            pendingFrame[ringSlot] = -1;
+            return;
+        }
+        slotFailed[ringSlot] = true;
+        pendingFrame[ringSlot] = frameIndex;
+    }
+
+    /** Waits all in-flight slots and returns their bitstreams in submission order. */
+    List<byte[]> drainRemaining()
+    {
+        int n = 0;
+        int[] slots = new int[EncodeResources.RING_DEPTH];
+        for (int s = 0; s < EncodeResources.RING_DEPTH; s++)
+        {
+            if (pendingFrame[s] != -1) slots[n++] = s;
+        }
+        for (int i = 1; i < n; i++)
+        {
+            int x = slots[i];
+            int j = i;
+            while (j > 0 && pendingFrame[slots[j - 1]] > pendingFrame[x])
+            {
+                slots[j] = slots[j - 1];
+                j--;
+            }
+            slots[j] = x;
+        }
+        List<byte[]> out = new ArrayList<>(n);
+        for (int i = 0; i < n; i++)
+        {
+            byte[] b = drainSlot(slots[i]);
+            if (b != null) out.add(b);
+        }
+        return out;
+    }
+
+    private byte[] drainSlot(int ringSlot)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+        int r = vkWaitForFences(device, encodeFences[ringSlot], true, FENCE_TIMEOUT_NS);
+        if (r != VK_SUCCESS)
+        {
+            log.error("vkWaitForFences slot {} failed: {}", ringSlot, r);
+            pendingFrame[ringSlot] = -1;
+            slotFailed[ringSlot] = false;
+            return null;
+        }
+        pendingFrame[ringSlot] = -1;
+        if (slotFailed[ringSlot])
+        {
+            slotFailed[ringSlot] = false;
+            return null;
+        }
+        try (MemoryStack stack = stackPush())
+        {
+            return readBitstream(stack, device, ringSlot);
+        }
+    }
+
+    private boolean resetSlotSync(VkDevice device, int ringSlot)
+    {
+        int r;
+        if ((r = vkResetFences(device, encodeFences[ringSlot])) != VK_SUCCESS)
+        {
+            log.error("vkResetFences slot {} failed: {}", ringSlot, r);
+            return false;
+        }
+        if ((r = vkResetCommandBuffer(commandBuffers[ringSlot], 0)) != VK_SUCCESS)
+        {
+            log.error("vkResetCommandBuffer(encode) slot {} failed: {}", ringSlot, r);
+            return false;
+        }
+        if ((r = vkResetCommandBuffer(gfxCommandBuffers[ringSlot], 0)) != VK_SUCCESS)
+        {
+            log.error("vkResetCommandBuffer(gfx) slot {} failed: {}", ringSlot, r);
+            return false;
+        }
+        return true;
+    }
+
+    private void stageNv12Frame(BufferedImage frame, int width, int height, int yBytes, int ringSlot)
+    {
+        // Mid-capture resize: frame may be smaller than (width, height).
+        int frameW = Math.min(Math.min(width, frame.getWidth()), encodedWidth);
+        int frameH = Math.min(Math.min(height, frame.getHeight()), encodedHeight);
+        Arrays.fill(paddedPixels, 0);
+        frame.getRGB(0, 0, frameW, frameH, paddedPixels, 0, encodedWidth);
+
+        int uvBytes = encodedWidth * encodedHeight / 2;
+        ByteBuffer staging = memByteBuffer(resources.stagingMappedPtr[ringSlot], yBytes + uvBytes);
+        staging.clear();
+        Nv12Converter.argbToNv12(paddedPixels, encodedWidth, encodedHeight, staging);
+    }
+
+    private boolean recordAndSubmitUpload(MemoryStack stack, int yBytes, int ringSlot, int frameIndex)
+    {
+        int encFamily = vulkanDevice.getVideoEncodeQueueFamily();
+        int gfxFamily = vulkanDevice.getGraphicsQueueFamily();
+        VkCommandBuffer gfxCb = gfxCommandBuffers[ringSlot];
+
+        VkCommandBufferBeginInfo beginInfo = VkCommandBufferBeginInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO)
+            .flags(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+        int r;
+        if ((r = vkBeginCommandBuffer(gfxCb, beginInfo)) != VK_SUCCESS)
+        {
+            log.error("vkBeginCommandBuffer(gfx) frame {} slot {} failed: {}", frameIndex, ringSlot, r);
+            return false;
+        }
+
+        // UNDEFINED -> TRANSFER_DST: previous contents discarded on re-entry.
+        VulkanBarriers.image(stack, gfxCb, resources.encodeInputImage[ringSlot],
+            VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            0, VK_ACCESS_TRANSFER_WRITE_BIT,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+            0,
+            VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED);
+
+        // Y plane: offset 0, aspect PLANE_0. UV plane: offset yBytes, PLANE_1.
+        // VUID-vkCmdCopyBufferToImage-dstImage-07981 requires one plane per region.
+        VkBufferImageCopy.Buffer regions = VkBufferImageCopy.calloc(2, stack);
+        regions.get(0)
+            .bufferOffset(0)
+            .bufferRowLength(0)
+            .bufferImageHeight(0)
+            .imageSubresource(s -> s
+                .aspectMask(VK_IMAGE_ASPECT_PLANE_0_BIT)
+                .mipLevel(0)
+                .baseArrayLayer(0)
+                .layerCount(1))
+            .imageOffset(o -> o.set(0, 0, 0))
+            .imageExtent(e -> e.set(encodedWidth, encodedHeight, 1));
+        regions.get(1)
+            .bufferOffset(yBytes)
+            .bufferRowLength(0)
+            .bufferImageHeight(0)
+            .imageSubresource(s -> s
+                .aspectMask(VK_IMAGE_ASPECT_PLANE_1_BIT)
+                .mipLevel(0)
+                .baseArrayLayer(0)
+                .layerCount(1))
+            .imageOffset(o -> o.set(0, 0, 0))
+            .imageExtent(e -> e.set(encodedWidth / 2, encodedHeight / 2, 1));
+
+        vkCmdCopyBufferToImage(gfxCb, resources.stagingBuffer[ringSlot], resources.encodeInputImage[ringSlot],
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, regions);
+
+        // QFOT release: graphics to encode family. Dst stages/access = 0 (spec).
+        VulkanBarriers.image(stack, gfxCb, resources.encodeInputImage[ringSlot],
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR,
+            VK_ACCESS_TRANSFER_WRITE_BIT, 0,
+            VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+            0,
+            gfxFamily, encFamily);
+
+        if ((r = vkEndCommandBuffer(gfxCb)) != VK_SUCCESS)
+        {
+            log.error("vkEndCommandBuffer(gfx) frame {} slot {} failed: {}", frameIndex, ringSlot, r);
+            return false;
+        }
+
+        VkCommandBufferSubmitInfo.Buffer cbInfo = VkCommandBufferSubmitInfo.calloc(1, stack)
+            .sType$Default()
+            .commandBuffer(gfxCb);
+        VkSemaphoreSubmitInfo.Buffer signalInfo = VkSemaphoreSubmitInfo.calloc(1, stack)
+            .sType$Default()
+            .semaphore(uploadSemaphores[ringSlot])
+            .stageMask(VK_PIPELINE_STAGE_2_COPY_BIT);
+        VkSubmitInfo2.Buffer gfxSubmit = VkSubmitInfo2.calloc(1, stack)
+            .sType$Default()
+            .pCommandBufferInfos(cbInfo)
+            .pSignalSemaphoreInfos(signalInfo);
+        if ((r = vkQueueSubmit2(vulkanDevice.getGraphicsQueue(), gfxSubmit, VK_NULL_HANDLE)) != VK_SUCCESS)
+        {
+            log.error("graphics vkQueueSubmit2 frame {} slot {} failed: {}", frameIndex, ringSlot, r);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean recordAndSubmitEncode(MemoryStack stack, boolean isIdr,
+                                          int dpbSlot, int refSlot, int frameIndex, int ringSlot)
+    {
+        int encFamily = vulkanDevice.getVideoEncodeQueueFamily();
+        int gfxFamily = vulkanDevice.getGraphicsQueueFamily();
+        VkCommandBuffer cb = commandBuffers[ringSlot];
+
+        VkCommandBufferBeginInfo beginInfo = VkCommandBufferBeginInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO)
+            .flags(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+        int r;
+        if ((r = vkBeginCommandBuffer(cb, beginInfo)) != VK_SUCCESS)
+        {
+            log.error("vkBeginCommandBuffer(encode) frame {} slot {} failed: {}", frameIndex, ringSlot, r);
+            return false;
+        }
+
+        // QFOT acquire: matches the release issued on the graphics queue.
+        VulkanBarriers.image(stack, cb, resources.encodeInputImage[ringSlot],
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR,
+            0, 0,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0,
+            0,
+            VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR,
+            VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR,
+            gfxFamily, encFamily);
+
+        // Rate-control must be explicitly configured on first frame; the
+        // firmware's default (NONE) ignores our constantQp and bitrate target.
+        if (frameIndex == 0)
+        {
+            recordRateControlScope(stack, cb);
+        }
+
+        // vkCmdResetQueryPool must happen OUTSIDE a video coding scope.
+        vkCmdResetQueryPool(cb, resources.feedbackQueryPool, ringSlot, 1);
+
+        recordEncodeCommand(stack, cb, isIdr, dpbSlot, refSlot, frameIndex, ringSlot);
+
+        VulkanBarriers.buffer(stack, cb, resources.bitstreamBuffer[ringSlot], EncodeResources.BITSTREAM_BUFFER_SIZE,
+            VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR, VK_ACCESS_HOST_READ_BIT,
+            VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR, VK_PIPELINE_STAGE_HOST_BIT);
+
+        if ((r = vkEndCommandBuffer(cb)) != VK_SUCCESS)
+        {
+            log.error("vkEndCommandBuffer(encode) frame {} slot {} failed: {}", frameIndex, ringSlot, r);
+            return false;
+        }
+
+        VkSemaphoreSubmitInfo.Buffer waitInfo = VkSemaphoreSubmitInfo.calloc(1, stack)
+            .sType$Default()
+            .semaphore(uploadSemaphores[ringSlot])
+            .stageMask(VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR);
+        VkCommandBufferSubmitInfo.Buffer cbSubmit = VkCommandBufferSubmitInfo.calloc(1, stack)
+            .sType$Default()
+            .commandBuffer(cb);
+        VkSubmitInfo2.Buffer encSubmit = VkSubmitInfo2.calloc(1, stack)
+            .sType$Default()
+            .pWaitSemaphoreInfos(waitInfo)
+            .pCommandBufferInfos(cbSubmit);
+        if ((r = vkQueueSubmit2(vulkanDevice.getVideoEncodeQueue(), encSubmit, encodeFences[ringSlot])) != VK_SUCCESS)
+        {
+            log.error("encode vkQueueSubmit2 frame {} slot {} failed: {}", frameIndex, ringSlot, r);
+            return false;
+        }
+        return true;
+    }
+
+    private byte[] readBitstream(MemoryStack stack, VkDevice device, int ringSlot)
+    {
+        // Feedback result layout (flags ordered by bit value per spec):
+        //   [0] = BITSTREAM_BUFFER_OFFSET (where the driver wrote, usually 0)
+        //   [1] = BITSTREAM_BYTES_WRITTEN
+        //   [2] = VkQueryResultStatusKHR (appended by WITH_STATUS_BIT)
+        LongBuffer results = stack.mallocLong(3);
+        int r = vkGetQueryPoolResults(device, resources.feedbackQueryPool, ringSlot, 1,
+            results, 3 * Long.BYTES,
+            VK_QUERY_RESULT_WAIT_BIT
+                | VK_QUERY_RESULT_WITH_STATUS_BIT_KHR
+                | VK_QUERY_RESULT_64_BIT);
+        if (r != VK_SUCCESS)
+        {
+            log.error("vkGetQueryPoolResults(encode feedback) slot {} failed: {}", ringSlot, r);
+            return null;
+        }
+        long status = results.get(2);
+        if (status <= 0)
+        {
+            // 0 = not ready (shouldn't happen under WAIT_BIT), <0 = driver-reported failure.
+            log.error("encode feedback slot {} status {}: bitstream undefined", ringSlot, status);
+            return null;
+        }
+
+        long offset = results.get(0);
+        long bytesWritten = results.get(1);
+        if (bytesWritten <= 0 || offset < 0
+            || offset + bytesWritten > EncodeResources.BITSTREAM_BUFFER_SIZE)
+        {
+            log.error("encode feedback slot {} out of range: offset={} bytes={}",
+                ringSlot, offset, bytesWritten);
+            return null;
+        }
+
+        VkMappedMemoryRange range = VkMappedMemoryRange.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE)
+            .memory(resources.bitstreamMemory[ringSlot])
+            .offset(0)
+            .size(VK_WHOLE_SIZE);
+        r = vkInvalidateMappedMemoryRanges(device, range);
+        if (r != VK_SUCCESS)
+        {
+            log.error("vkInvalidateMappedMemoryRanges slot {} failed: {}", ringSlot, r);
+            return null;
+        }
+
+        ByteBuffer bitstream = memByteBuffer(resources.bitstreamMappedPtr[ringSlot], EncodeResources.BITSTREAM_BUFFER_SIZE);
+        byte[] naluData = new byte[(int) bytesWritten];
+        bitstream.position((int) offset);
+        bitstream.get(naluData, 0, (int) bytesWritten);
+        return naluData;
+    }
+
+    private void recordEncodeCommand(MemoryStack stack, VkCommandBuffer cb,
+                                     boolean isIdr, int dpbSlot, int refSlot,
+                                     int frameIndex, int ringSlot)
+    {
+        if (frameIndex == 0)
+        {
+            transitionDpbForFirstFrame(stack, cb);
+        }
+
+        boolean hasReference = !isIdr;
+
+        VkVideoPictureResourceInfoKHR srcPicture = VkVideoPictureResourceInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
+            .codedOffset(o -> o.set(0, 0))
+            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
+            .baseArrayLayer(0)
+            .imageViewBinding(resources.encodeInputImageView[ringSlot]);
+
+        VkVideoReferenceSlotInfoKHR setupSlot = buildSetupReferenceSlot(
+            stack, isIdr, dpbSlot, frameIndex);
+
+        VkVideoEncodeH264PictureInfoKHR picInfo = buildPictureInfo(
+            stack, isIdr, hasReference, refSlot, frameIndex);
+
+        VkVideoEncodeRateControlInfoKHR rcInfo = buildRateControlChain(stack);
+
+        // GopRemainingFrameInfo hints the firmware about upcoming I/P counts;
+        // required in practice on VCN even though caps reports it as optional.
+        int frameInGop = frameIndex % fps;
+        int remainingInGop = fps - frameInGop;
+        int remainingI = isIdr ? 1 : 0;
+        int remainingP = isIdr ? (remainingInGop - 1) : remainingInGop;
+        VkVideoEncodeH264GopRemainingFrameInfoKHR gopRemaining =
+            VkVideoEncodeH264GopRemainingFrameInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_KHR)
+                .pNext(rcInfo.address())
+                .useGopRemainingFrames(true)
+                .gopRemainingI(remainingI)
+                .gopRemainingP(remainingP)
+                .gopRemainingB(0);
+
+        VkVideoBeginCodingInfoKHR beginCoding = VkVideoBeginCodingInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR)
+            .pNext(gopRemaining.address())
+            .videoSession(sessionConfig.getVideoSession())
+            .videoSessionParameters(sessionConfig.getSessionParameters())
+            .pReferenceSlots(buildBeginCodingSlots(stack, hasReference, dpbSlot, refSlot, frameIndex, isIdr));
+
+        vkCmdBeginVideoCodingKHR(cb, beginCoding);
+
+        VkVideoEncodeInfoKHR encodeInfo = VkVideoEncodeInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR)
+            .pNext(picInfo.address())
+            .dstBuffer(resources.bitstreamBuffer[ringSlot])
+            .dstBufferOffset(0)
+            .dstBufferRange(EncodeResources.BITSTREAM_BUFFER_SIZE)
+            .srcPictureResource(srcPicture)
+            .pSetupReferenceSlot(setupSlot)
+            .pReferenceSlots(hasReference
+                ? buildEncodeReferenceSlots(stack, refSlot, frameIndex)
+                : null);
+
+        vkCmdBeginQuery(cb, resources.feedbackQueryPool, ringSlot, 0);
+        vkCmdEncodeVideoKHR(cb, encodeInfo);
+        vkCmdEndQuery(cb, resources.feedbackQueryPool, ringSlot);
+
+        VkVideoEndCodingInfoKHR endCoding = VkVideoEndCodingInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR);
+        vkCmdEndVideoCodingKHR(cb, endCoding);
+    }
+
+    /** frame_num within the current GOP, modulo MaxFrameNum (16; SPS
+     *  log2_max_frame_num_minus4 = 0). Resets to 0 at each IDR. */
+    private int frameNumInGop(int frameIndex)
+    {
+        return (frameIndex % fps) & 0xF;
+    }
+
+    /** POC LSB, modulo MaxPicOrderCntLsb (256). Must wrap independently
+     *  of frame_num; sharing the mod-16 wrap causes mid-GOP display
+     *  re-ordering glitches in the decoder. */
+    private int pocInGop(int frameIndex)
+    {
+        return ((frameIndex % fps) * 2) & 0xFF;
+    }
+
+    /**
+     * Transitions the DPB image into {@code VIDEO_ENCODE_DPB_KHR} on the
+     * encode queue. Explicit src=dst=encodeFamily is required; IGNORED
+     * leaves the image without stable ownership and subsequent DPB reads
+     * see garbage on AMD.
+     */
+    private void transitionDpbForFirstFrame(MemoryStack stack, VkCommandBuffer cb)
+    {
+        int encFamily = vulkanDevice.getVideoEncodeQueueFamily();
+        VkImageMemoryBarrier2.Buffer barrier = VkImageMemoryBarrier2.calloc(1, stack)
+            .sType(VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2)
+            .srcStageMask(VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT)
+            .srcAccessMask(0)
+            .dstStageMask(VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR)
+            .dstAccessMask(VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR | VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR)
+            .oldLayout(VK_IMAGE_LAYOUT_UNDEFINED)
+            .newLayout(VK_IMAGE_LAYOUT_VIDEO_ENCODE_DPB_KHR)
+            .srcQueueFamilyIndex(encFamily)
+            .dstQueueFamilyIndex(encFamily)
+            .image(resources.dpbImage)
+            .subresourceRange(r -> r
+                .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
+                .baseMipLevel(0)
+                .levelCount(1)
+                .baseArrayLayer(0)
+                .layerCount(2));
+
+        VkDependencyInfo depInfo = VkDependencyInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_DEPENDENCY_INFO)
+            .pImageMemoryBarriers(barrier);
+        vkCmdPipelineBarrier2(cb, depInfo);
+    }
+
+    /**
+     * The setup slot describes the picture being reconstructed into the
+     * DPB for this frame. VUID-VkVideoEncodeH264DpbSlotInfoKHR-
+     * pStdReferenceInfo-parameter requires the std reference info to be
+     * non-null.
+     */
+    private VkVideoReferenceSlotInfoKHR buildSetupReferenceSlot(
+        MemoryStack stack, boolean codeAsIdr, int dpbSlot, int frameIndex)
+    {
+        StdVideoEncodeH264ReferenceInfo stdRefInfo = StdVideoEncodeH264ReferenceInfo.calloc(stack)
+            .primary_pic_type(codeAsIdr ? STD_VIDEO_H264_PICTURE_TYPE_IDR : STD_VIDEO_H264_PICTURE_TYPE_P)
+            .FrameNum(codeAsIdr ? 0 : frameNumInGop(frameIndex))
+            .PicOrderCnt(pocInGop(frameIndex));
+
+        VkVideoEncodeH264DpbSlotInfoKHR h264DpbSlot = VkVideoEncodeH264DpbSlotInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR)
+            .pStdReferenceInfo(stdRefInfo);
+
+        // Single layered view over the DPB image; baseArrayLayer selects slot.
+        VkVideoPictureResourceInfoKHR setupPicResource = VkVideoPictureResourceInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
+            .codedOffset(o -> o.set(0, 0))
+            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
+            .baseArrayLayer(dpbSlot)
+            .imageViewBinding(resources.dpbImageViews[dpbSlot]);
+
+        return VkVideoReferenceSlotInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
+            .pNext(h264DpbSlot.address())
+            .slotIndex(dpbSlot)
+            .pPictureResource(setupPicResource);
+    }
+
+    private VkVideoEncodeH264PictureInfoKHR buildPictureInfo(
+        MemoryStack stack, boolean codeAsIdr, boolean hasReference,
+        int refSlot, int frameIndex)
+    {
+        int picType = codeAsIdr ? STD_VIDEO_H264_PICTURE_TYPE_IDR : STD_VIDEO_H264_PICTURE_TYPE_P;
+        int sliceType = codeAsIdr ? STD_VIDEO_H264_SLICE_TYPE_I : STD_VIDEO_H264_SLICE_TYPE_P;
+
+        // pRefLists is required on every frame (IDRs included) so the DPB's
+        // reconstructed picture is tracked as a reference. Both counters are 0:
+        // 0xFF in num_ref_idx_lN_active_minus1 is read by some drivers as
+        // "no refs at all" and disables inter-prediction.
+        StdVideoEncodeH264ReferenceListsInfo refLists = StdVideoEncodeH264ReferenceListsInfo.calloc(stack);
+        for (int i = 0; i < 32; i++)
+        {
+            refLists.RefPicList0(i, (byte) 0xFF);
+            refLists.RefPicList1(i, (byte) 0xFF);
+        }
+        if (hasReference)
+        {
+            refLists.RefPicList0(0, (byte) refSlot);
+        }
+
+        StdVideoEncodeH264PictureInfoFlags picFlags = StdVideoEncodeH264PictureInfoFlags.calloc(stack)
+            .IdrPicFlag(codeAsIdr)
+            .is_reference(true);
+
+        StdVideoEncodeH264SliceHeader sliceHeader = StdVideoEncodeH264SliceHeader.calloc(stack)
+            .slice_type(sliceType);
+
+        // VUID-08269: constantQp must be 0 when rate control is enabled.
+        // 18/20 under DISABLED targets x264 CRF-18 visual quality.
+        int constantQp = useVbr() ? 0 : (codeAsIdr ? 18 : 20);
+        VkVideoEncodeH264NaluSliceInfoKHR.Buffer naluSlice = VkVideoEncodeH264NaluSliceInfoKHR.calloc(1, stack);
+        naluSlice.get(0)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR)
+            .constantQp(constantQp)
+            .pStdSliceHeader(sliceHeader);
+
+        StdVideoEncodeH264PictureInfo stdPicInfo = StdVideoEncodeH264PictureInfo.calloc(stack)
+            .flags(picFlags)
+            .idr_pic_id((short) frameIndex)
+            .primary_pic_type(picType)
+            .frame_num(codeAsIdr ? 0 : frameNumInGop(frameIndex))
+            .PicOrderCnt(pocInGop(frameIndex))
+            .pRefLists(refLists);
+
+        return VkVideoEncodeH264PictureInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR)
+            .pNaluSliceEntries(naluSlice)
+            .pStdPictureInfo(stdPicInfo)
+            .generatePrefixNalu(false);
+    }
+
+    /**
+     * Builds the reference slot array for BeginCoding. Every slot needs
+     * its {@link org.lwjgl.vulkan.VkVideoEncodeH264DpbSlotInfoKHR} chained
+     * in pNext so the firmware knows the codec-level identity of what lives
+     * there; missing this makes the encoder silently drop to intra-only P
+     * frames. Order: existing references first, then the setup slot last
+     * with {@code slotIndex = -1}.
+     */
+    private VkVideoReferenceSlotInfoKHR.Buffer buildBeginCodingSlots(
+        MemoryStack stack, boolean hasReference, int dpbSlot, int refSlot,
+        int frameIndex, boolean codeAsIdr)
+    {
+        int setupFrameNum = codeAsIdr ? 0 : frameNumInGop(frameIndex);
+        int setupPoc = pocInGop(frameIndex);
+        int setupPicType = codeAsIdr
+            ? STD_VIDEO_H264_PICTURE_TYPE_IDR
+            : STD_VIDEO_H264_PICTURE_TYPE_P;
+        StdVideoEncodeH264ReferenceInfo setupRefInfo = StdVideoEncodeH264ReferenceInfo.calloc(stack)
+            .primary_pic_type(setupPicType)
+            .FrameNum(setupFrameNum)
+            .PicOrderCnt(setupPoc);
+        VkVideoEncodeH264DpbSlotInfoKHR setupDpbSlotInfo = VkVideoEncodeH264DpbSlotInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR)
+            .pStdReferenceInfo(setupRefInfo);
+
+        VkVideoPictureResourceInfoKHR setupSlotPic = VkVideoPictureResourceInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
+            .codedOffset(o -> o.set(0, 0))
+            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
+            .baseArrayLayer(dpbSlot)
+            .imageViewBinding(resources.dpbImageViews[dpbSlot]);
+
+        if (!hasReference)
+        {
+            VkVideoReferenceSlotInfoKHR.Buffer slots = VkVideoReferenceSlotInfoKHR.calloc(1, stack);
+            slots.get(0)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
+                .pNext(setupDpbSlotInfo.address())
+                .slotIndex(-1)
+                .pPictureResource(setupSlotPic);
+            return slots;
+        }
+
+        // Reference slot: the previous frame. Its IDR status = whether the
+        // prior frame was at the GOP boundary.
+        boolean refIsIdr = (frameIndex - 1) % fps == 0;
+        int refFrameNum = refIsIdr ? 0 : frameNumInGop(frameIndex - 1);
+        int refPoc = pocInGop(frameIndex - 1);
+        int refPicType = refIsIdr
+            ? STD_VIDEO_H264_PICTURE_TYPE_IDR
+            : STD_VIDEO_H264_PICTURE_TYPE_P;
+        StdVideoEncodeH264ReferenceInfo refInfo = StdVideoEncodeH264ReferenceInfo.calloc(stack)
+            .primary_pic_type(refPicType)
+            .FrameNum(refFrameNum)
+            .PicOrderCnt(refPoc);
+        VkVideoEncodeH264DpbSlotInfoKHR refDpbSlotInfo = VkVideoEncodeH264DpbSlotInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR)
+            .pStdReferenceInfo(refInfo);
+
+        VkVideoPictureResourceInfoKHR refSlotPic = VkVideoPictureResourceInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
+            .codedOffset(o -> o.set(0, 0))
+            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
+            .baseArrayLayer(refSlot)
+            .imageViewBinding(resources.dpbImageViews[refSlot]);
+
+        VkVideoReferenceSlotInfoKHR.Buffer slots = VkVideoReferenceSlotInfoKHR.calloc(2, stack);
+        slots.get(0)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
+            .pNext(refDpbSlotInfo.address())
+            .slotIndex(refSlot)
+            .pPictureResource(refSlotPic);
+        slots.get(1)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
+            .pNext(setupDpbSlotInfo.address())
+            .slotIndex(-1)
+            .pPictureResource(setupSlotPic);
+        return slots;
+    }
+
+    /**
+     * Records a dedicated coding scope containing only the initial
+     * {@code RESET | RATE_CONTROL | QUALITY_LEVEL} command. Issued as its own
+     * scope (no encode command follows) so BeginCoding sees the session in
+     * its DEFAULT rate-control state; chaining an rc_info there would violate
+     * VUID-08254. The control command promotes the session to VBR before the
+     * first encode scope opens.
+     */
+    private void recordRateControlScope(MemoryStack stack, VkCommandBuffer cb)
+    {
+        VkVideoEncodeRateControlInfoKHR rcInfo = buildRateControlChain(stack);
+
+        VkVideoEncodeQualityLevelInfoKHR qlInfo = VkVideoEncodeQualityLevelInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR)
+            .pNext(rcInfo.address())
+            .qualityLevel(2);
+
+        VkVideoBeginCodingInfoKHR begin = VkVideoBeginCodingInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR)
+            .videoSession(sessionConfig.getVideoSession())
+            .videoSessionParameters(sessionConfig.getSessionParameters());
+        vkCmdBeginVideoCodingKHR(cb, begin);
+
+        VkVideoCodingControlInfoKHR ctrl = VkVideoCodingControlInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR)
+            .pNext(qlInfo.address())
+            .flags(VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR
+                 | VK_VIDEO_CODING_CONTROL_ENCODE_QUALITY_LEVEL_BIT_KHR
+                 | VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR);
+        vkCmdControlVideoCodingKHR(cb, ctrl);
+
+        VkVideoEndCodingInfoKHR end = VkVideoEndCodingInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR);
+        vkCmdEndVideoCodingKHR(cb, end);
+    }
+
+    /** True iff the driver advertised VBR support. CBR is another option but
+     *  VBR adapts better to the mixed-complexity content this plugin captures
+     *  (static UI + occasional motion bursts). */
+    private boolean useVbr()
+    {
+        return (caps.getSupportedRateControlModes() & VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR) != 0;
+    }
+
+    /**
+     * Builds the rate-control pNext chain and returns the outer
+     * {@link VkVideoEncodeRateControlInfoKHR}. Falls back to DISABLED/CQP
+     * when the driver doesn't advertise VBR.
+     *
+     * Chain shape:
+     *   VkVideoEncodeRateControlInfoKHR
+     *     pLayers -> VkVideoEncodeRateControlLayerInfoKHR
+     *                  pNext -> VkVideoEncodeH264RateControlLayerInfoKHR
+     *     pNext   -> VkVideoEncodeH264RateControlInfoKHR
+     */
+    private VkVideoEncodeRateControlInfoKHR buildRateControlChain(MemoryStack stack)
+    {
+        if (!useVbr())
+        {
+            return VkVideoEncodeRateControlInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR)
+                .rateControlMode(VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR);
+        }
+
+        VkVideoEncodeH264RateControlLayerInfoKHR h264LayerInfo =
+            VkVideoEncodeH264RateControlLayerInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR);
+
+        VkVideoEncodeRateControlLayerInfoKHR.Buffer encodeLayer =
+            VkVideoEncodeRateControlLayerInfoKHR.calloc(1, stack);
+        encodeLayer.get(0)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR)
+            .pNext(h264LayerInfo.address())
+            .averageBitrate(VBR_AVERAGE_BITRATE_BPS)
+            .maxBitrate(VBR_MAX_BITRATE_BPS)
+            .frameRateNumerator(fps)
+            .frameRateDenominator(1);
+
+        // IPPP GOP, no B-frames.
+        VkVideoEncodeH264RateControlInfoKHR h264RcInfo =
+            VkVideoEncodeH264RateControlInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR)
+                .flags(VK_VIDEO_ENCODE_H264_RATE_CONTROL_REGULAR_GOP_BIT_KHR
+                    | VK_VIDEO_ENCODE_H264_RATE_CONTROL_REFERENCE_PATTERN_FLAT_BIT_KHR)
+                .gopFrameCount(fps)
+                .idrPeriod(fps)
+                .consecutiveBFrameCount(0)
+                .temporalLayerCount(1);
+
+        return VkVideoEncodeRateControlInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR)
+            .pNext(h264RcInfo.address())
+            .rateControlMode(VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR)
+            .pLayers(encodeLayer)
+            .virtualBufferSizeInMs(VBR_VIRTUAL_BUFFER_MS)
+            .initialVirtualBufferSizeInMs(VBR_INITIAL_VIRTUAL_BUFFER_MS);
+    }
+
+    /**
+     * Builds {@code VkVideoEncodeInfoKHR.pReferenceSlots} for a P-frame.
+     * Each ref slot's std info describes the picture *already in* that
+     * slot, not the one being encoded.
+     */
+    private VkVideoReferenceSlotInfoKHR.Buffer buildEncodeReferenceSlots(
+        MemoryStack stack, int refSlot, int frameIndex)
+    {
+        boolean refIsIdr = (frameIndex - 1) % fps == 0;
+        int refFrameNum = refIsIdr ? 0 : frameNumInGop(frameIndex - 1);
+        int refPoc = pocInGop(frameIndex - 1);
+        int refPicType = refIsIdr
+            ? STD_VIDEO_H264_PICTURE_TYPE_IDR
+            : STD_VIDEO_H264_PICTURE_TYPE_P;
+        StdVideoEncodeH264ReferenceInfo prevRefInfo = StdVideoEncodeH264ReferenceInfo.calloc(stack)
+            .primary_pic_type(refPicType)
+            .FrameNum(refFrameNum)
+            .PicOrderCnt(refPoc);
+        VkVideoEncodeH264DpbSlotInfoKHR refDpbSlot = VkVideoEncodeH264DpbSlotInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR)
+            .pStdReferenceInfo(prevRefInfo);
+
+        VkVideoPictureResourceInfoKHR refPicResource = VkVideoPictureResourceInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
+            .codedOffset(o -> o.set(0, 0))
+            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
+            .baseArrayLayer(refSlot)
+            .imageViewBinding(resources.dpbImageViews[refSlot]);
+
+        return VkVideoReferenceSlotInfoKHR.calloc(1, stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
+            .pNext(refDpbSlot.address())
+            .slotIndex(refSlot)
+            .pPictureResource(refPicResource);
+    }
+
+}

--- a/src/main/java/com/osrstracker/video/encode/H264SessionConfig.java
+++ b/src/main/java/com/osrstracker/video/encode/H264SessionConfig.java
@@ -25,6 +25,7 @@
 package com.osrstracker.video.encode;
 
 import lombok.extern.slf4j.Slf4j;
+import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.vulkan.*;
@@ -35,17 +36,15 @@ import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 
 import static org.lwjgl.system.MemoryStack.stackPush;
-import static org.lwjgl.vulkan.EXTVideoEncodeH264.*;
+import static org.lwjgl.vulkan.KHRVideoEncodeH264.*;
 import static org.lwjgl.vulkan.KHRVideoEncodeQueue.*;
 import static org.lwjgl.vulkan.KHRVideoQueue.*;
 import static org.lwjgl.vulkan.VK10.*;
 import static org.lwjgl.vulkan.video.STDVulkanVideoCodecH264.*;
 
 /**
- * Creates and manages a Vulkan Video Session with H.264 Baseline SPS/PPS.
- *
- * Ported from pyroenc patterns, adapted for LWJGL 3.3.2 EXT bindings.
- * Baseline profile: CAVLC only, no B-frames, no weighted prediction.
+ * Owns the {@code VkVideoSessionKHR} and its H.264 SPS/PPS parameters.
+ * One instance per dimension / FPS configuration.
  */
 @Slf4j
 public class H264SessionConfig implements AutoCloseable
@@ -59,14 +58,16 @@ public class H264SessionConfig implements AutoCloseable
     private long videoSession = VK_NULL_HANDLE;
     private long sessionParameters = VK_NULL_HANDLE;
 
-    // Session memory allocations (must be freed on close)
     private long[] sessionMemoryAllocations;
 
-    // Heap-allocated structs that live for the session lifetime
+    // These structs are passed to the driver and must live for the
+    // lifetime of the session parameters.
     private StdVideoH264SequenceParameterSet sps;
     private StdVideoH264PictureParameterSet pps;
     private StdVideoH264SpsFlags spsFlags;
     private StdVideoH264PpsFlags ppsFlags;
+    private StdVideoH264SequenceParameterSetVui spsVui;
+    private StdVideoH264SpsVuiFlags spsVuiFlags;
 
     private boolean closed = false;
 
@@ -79,15 +80,12 @@ public class H264SessionConfig implements AutoCloseable
         this.fps = fps;
     }
 
-    /**
-     * Creates the video session and session parameters (SPS + PPS).
-     */
+    /** Creates the video session and uploads the SPS/PPS. */
     public void initialize()
     {
         createVideoSession();
         bindSessionMemory();
         createSessionParameters();
-        log.debug("H.264 session created: {}x{} @ {} FPS, Baseline", width, height, fps);
     }
 
     private void createVideoSession()
@@ -96,15 +94,17 @@ public class H264SessionConfig implements AutoCloseable
         {
             VkVideoProfileInfoKHR videoProfile = caps.buildVideoProfile(stack);
 
-            // VkExtensionProperties is read-only in LWJGL 3.3.2, write fields directly.
-            // Layout: extensionName (256 bytes) + specVersion (4 bytes)
+            // LWJGL 3.3.2's VkExtensionProperties is read-only; poke the
+            // extensionName / specVersion fields via raw memory.
             VkExtensionProperties stdHeader = VkExtensionProperties.calloc(stack);
             ByteBuffer nameBytes = stack.UTF8(VK_STD_VULKAN_VIDEO_CODEC_H264_ENCODE_EXTENSION_NAME);
             MemoryUtil.memCopy(MemoryUtil.memAddress(nameBytes), MemoryUtil.memAddress(stdHeader.extensionName()),
                 Math.min(nameBytes.remaining(), stdHeader.extensionName().remaining()));
-            // specVersion is at offset 256 (after extensionName[256])
             MemoryUtil.memPutInt(stdHeader.address() + 256, VK_STD_VULKAN_VIDEO_CODEC_H264_ENCODE_SPEC_VERSION);
 
+            // 2 DPB slots / 1 active ref are the minimum for IPPP ping-pong.
+            // Over-declaring against the caps max makes VCN misplace the
+            // reference picture and fall back to intra-only.
             VkVideoSessionCreateInfoKHR createInfo = VkVideoSessionCreateInfoKHR.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR)
                 .queueFamilyIndex(vulkanDevice.getVideoEncodeQueueFamily())
@@ -112,8 +112,8 @@ public class H264SessionConfig implements AutoCloseable
                 .pictureFormat(caps.getPictureFormat())
                 .maxCodedExtent(e -> e.width(width).height(height))
                 .referencePictureFormat(caps.getPictureFormat())
-                .maxDpbSlots(2) // I+P ping-pong
-                .maxActiveReferencePictures(1) // P-frame refs 1 prior frame
+                .maxDpbSlots(2)
+                .maxActiveReferencePictures(1)
                 .pStdHeaderVersion(stdHeader);
 
             LongBuffer pSession = stack.mallocLong(1);
@@ -197,19 +197,46 @@ public class H264SessionConfig implements AutoCloseable
         // These structs must survive beyond the stack scope (session lifetime)
         spsFlags = StdVideoH264SpsFlags.calloc()
             .frame_mbs_only_flag(true)
-            .direct_8x8_inference_flag(true);
+            .direct_8x8_inference_flag(true)
+            .vui_parameters_present_flag(true);
+
+        // SPS VUI: self-describe the bitstream as BT.601 full-range so decoders
+        // render 1:1 with the source RGB without relying on container metadata.
+        // matrix=6 pairs with Nv12Converter's BT.601-JFIF coefficients.
+        spsVuiFlags = StdVideoH264SpsVuiFlags.calloc()
+            .video_signal_type_present_flag(true)
+            .video_full_range_flag(true)
+            .color_description_present_flag(true)
+            .timing_info_present_flag(true)
+            .fixed_frame_rate_flag(true);
+
+        spsVui = StdVideoH264SequenceParameterSetVui.calloc()
+            .flags(spsVuiFlags)
+            .video_format((byte) 5)          // 5 = Unspecified
+            .colour_primaries((byte) 2)      // 2 = Unspecified
+            .transfer_characteristics((byte) 2) // 2 = Unspecified
+            .matrix_coefficients((byte) 6)   // 6 = BT.601
+            .num_units_in_tick(1)
+            .time_scale(fps * 2);            // H.264 convention: time_scale = 2·fps when tick=1
 
         sps = StdVideoH264SequenceParameterSet.calloc()
             .flags(spsFlags)
-            .profile_idc(STD_VIDEO_H264_PROFILE_IDC_BASELINE)
+            .pSequenceParameterSetVui(spsVui)
+            .profile_idc(STD_VIDEO_H264_PROFILE_IDC_HIGH)
             .level_idc(STD_VIDEO_H264_LEVEL_IDC_4_0)
             .chroma_format_idc(STD_VIDEO_H264_CHROMA_FORMAT_IDC_420)
             .seq_parameter_set_id((byte) 0)
             .bit_depth_luma_minus8((byte) 0)
             .bit_depth_chroma_minus8((byte) 0)
-            .log2_max_frame_num_minus4((byte) 0) // max_frame_num = 16
-            .pic_order_cnt_type(STD_VIDEO_H264_POC_TYPE_2) // No POC signaling needed for I+P
-            .max_num_ref_frames((byte) 1) // 1 reference frame for P-frames
+            // MaxFrameNum = 16; frame_num is allowed to wrap mid-GOP per spec.
+            .log2_max_frame_num_minus4((byte) 0)
+            // POC_TYPE_0 signals POC LSB explicitly per slice; some encoder
+            // implementations don't handle POC_TYPE_2 for inter-prediction.
+            .pic_order_cnt_type(STD_VIDEO_H264_POC_TYPE_0)
+            .log2_max_pic_order_cnt_lsb_minus4((byte) 4)
+            // IPPP only references the previous frame; declaring more confuses
+            // the encoder about back-buffer tracking.
+            .max_num_ref_frames((byte) 1)
             .pic_width_in_mbs_minus1((width + 15) / 16 - 1)
             .pic_height_in_map_units_minus1((height + 15) / 16 - 1);
 
@@ -223,8 +250,14 @@ public class H264SessionConfig implements AutoCloseable
             sps.frame_crop_bottom_offset((mbHeight - height) / 2);
         }
 
+        // CABAC unlocks the hardware rate-control path on AMD; CAVLC falls
+        // back to fixed QP. Gate on caps.stdSyntaxFlags.
+        boolean cabacAvailable = (caps.getH264StdSyntaxFlags()
+            & VK_VIDEO_ENCODE_H264_STD_ENTROPY_CODING_MODE_FLAG_SET_BIT_KHR) != 0;
+
         ppsFlags = StdVideoH264PpsFlags.calloc()
-            .entropy_coding_mode_flag(false); // false = CAVLC (required for Baseline)
+            .entropy_coding_mode_flag(cabacAvailable)
+            .deblocking_filter_control_present_flag(true);
 
         pps = StdVideoH264PictureParameterSet.calloc()
             .flags(ppsFlags)
@@ -244,23 +277,30 @@ public class H264SessionConfig implements AutoCloseable
                 StdVideoH264PictureParameterSet.calloc(1, stack);
             ppsBuffer.put(0, pps);
 
-            VkVideoEncodeH264SessionParametersAddInfoEXT addInfo =
-                VkVideoEncodeH264SessionParametersAddInfoEXT.calloc(stack)
-                    .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT)
+            VkVideoEncodeH264SessionParametersAddInfoKHR addInfo =
+                VkVideoEncodeH264SessionParametersAddInfoKHR.calloc(stack)
+                    .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR)
                     .pStdSPSs(spsBuffer)
                     .pStdPPSs(ppsBuffer);
 
-            VkVideoEncodeH264SessionParametersCreateInfoEXT h264ParamsInfo =
-                VkVideoEncodeH264SessionParametersCreateInfoEXT.calloc(stack)
-                    .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT)
+            VkVideoEncodeH264SessionParametersCreateInfoKHR h264ParamsInfo =
+                VkVideoEncodeH264SessionParametersCreateInfoKHR.calloc(stack)
+                    .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR)
                     .maxStdSPSCount(1)
                     .maxStdPPSCount(1)
                     .pParametersAddInfo(addInfo);
 
+            // Session parameters must declare the quality level; VUID-08318
+            // requires this to match the level passed to the control command.
+            VkVideoEncodeQualityLevelInfoKHR qlInfo = VkVideoEncodeQualityLevelInfoKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR)
+                .pNext(h264ParamsInfo.address())
+                .qualityLevel(2);
+
             VkVideoSessionParametersCreateInfoKHR paramsCreateInfo =
                 VkVideoSessionParametersCreateInfoKHR.calloc(stack)
                     .sType(VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR)
-                    .pNext(h264ParamsInfo.address())
+                    .pNext(qlInfo.address())
                     .videoSession(videoSession);
 
             LongBuffer pParams = stack.mallocLong(1);
@@ -302,8 +342,65 @@ public class H264SessionConfig implements AutoCloseable
 
     public long getVideoSession() { return videoSession; }
     public long getSessionParameters() { return sessionParameters; }
-    public int getWidth() { return width; }
-    public int getHeight() { return height; }
+
+    /**
+     * Fetches the encoded SPS and PPS NAL bodies from the driver via
+     * {@code vkGetEncodedVideoSessionParametersKHR}.
+     *
+     * The returned blob is the raw driver-produced concatenation: one or more
+     * NAL unit bodies, without Annex-B start codes.
+     */
+    public byte[] fetchEncodedSpsPps(int stdSpsId, int stdPpsId, boolean writeSps, boolean writePps)
+    {
+        VkDevice device = vulkanDevice.getDevice();
+
+        try (MemoryStack stack = stackPush())
+        {
+            VkVideoEncodeH264SessionParametersGetInfoKHR h264Get =
+                VkVideoEncodeH264SessionParametersGetInfoKHR.calloc(stack)
+                    .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_KHR)
+                    .writeStdSPS(writeSps)
+                    .writeStdPPS(writePps)
+                    .stdSPSId(stdSpsId)
+                    .stdPPSId(stdPpsId);
+
+            VkVideoEncodeSessionParametersGetInfoKHR getInfo =
+                VkVideoEncodeSessionParametersGetInfoKHR.calloc(stack)
+                    .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_GET_INFO_KHR)
+                    .pNext(h264Get.address())
+                    .videoSessionParameters(sessionParameters);
+
+            PointerBuffer pDataSize = stack.mallocPointer(1);
+            pDataSize.put(0, 0L);
+
+            int r = vkGetEncodedVideoSessionParametersKHR(device, getInfo, null, pDataSize, null);
+            if (r != VK_SUCCESS)
+            {
+                log.warn("vkGetEncodedVideoSessionParametersKHR size query failed: {}", r);
+                return null;
+            }
+            int size = (int) pDataSize.get(0);
+            if (size == 0) return null;
+
+            ByteBuffer data = MemoryUtil.memAlloc(size);
+            try
+            {
+                r = vkGetEncodedVideoSessionParametersKHR(device, getInfo, null, pDataSize, data);
+                if (r != VK_SUCCESS)
+                {
+                    log.warn("vkGetEncodedVideoSessionParametersKHR fetch failed: {}", r);
+                    return null;
+                }
+                byte[] out = new byte[(int) pDataSize.get(0)];
+                data.get(out);
+                return out;
+            }
+            finally
+            {
+                MemoryUtil.memFree(data);
+            }
+        }
+    }
 
     @Override
     public void close()
@@ -343,7 +440,7 @@ public class H264SessionConfig implements AutoCloseable
         if (ppsFlags != null) ppsFlags.free();
         if (sps != null) sps.free();
         if (spsFlags != null) spsFlags.free();
-
-        log.debug("H.264 session closed");
+        if (spsVui != null) spsVui.free();
+        if (spsVuiFlags != null) spsVuiFlags.free();
     }
 }

--- a/src/main/java/com/osrstracker/video/encode/LocalMp4Writer.java
+++ b/src/main/java/com/osrstracker/video/encode/LocalMp4Writer.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Mux an H.264 Annex B bitstream to a faststart MP4 on disk. */
+public final class LocalMp4Writer
+{
+    private static final int TIMESCALE = 90_000;
+
+    private LocalMp4Writer() {}
+
+    public static void write(byte[] h264, byte[] driverSpsPps,
+                             int width, int height, int fps, Path out) throws IOException
+    {
+        java.nio.file.Files.write(out, toBytes(h264, driverSpsPps, width, height, fps));
+    }
+
+    public static byte[] toBytes(byte[] h264, byte[] driverSpsPps,
+                                 int width, int height, int fps)
+    {
+        return toBytes(h264, driverSpsPps, width, height, fps, null);
+    }
+
+    public static byte[] toBytes(byte[] h264, byte[] driverSpsPps,
+                                 int width, int height, int fps, long[] frameTimestampsMs)
+    {
+        Parsed p = analyze(h264);
+        if (p.sps == null || p.pps == null)
+        {
+            if (driverSpsPps == null)
+            {
+                throw new IllegalStateException(
+                    "bitstream missing SPS/PPS and driver returned no parameter blob");
+            }
+            byte[][] sp = extractSpsPpsFromDriverBlob(driverSpsPps);
+            p.sps = sp[0];
+            p.pps = sp[1];
+        }
+
+        int[] durations = computeDurations(p.frameStartIndices.length, fps, frameTimestampsMs);
+
+        Mp4Writer.Built built = Mp4Writer.buildSamples(h264, p.frameStartIndices, p.keyframes, durations);
+        return new Mp4Writer(width, height, TIMESCALE, p.sps, p.pps)
+            .writeToBytes(built.avccBitstream, built.samples);
+    }
+
+    private static int[] computeDurations(int sampleCount, int fps, long[] timestampsMs)
+    {
+        int[] durations = new int[sampleCount];
+        int fallbackTicks = Math.max(1, TIMESCALE / Math.max(1, fps));
+        if (timestampsMs == null || timestampsMs.length != sampleCount || sampleCount < 2)
+        {
+            Arrays.fill(durations, fallbackTicks);
+            return durations;
+        }
+        for (int i = 0; i < sampleCount - 1; i++)
+        {
+            long deltaMs = timestampsMs[i + 1] - timestampsMs[i];
+            if (deltaMs <= 0)
+            {
+                durations[i] = fallbackTicks;
+            }
+            else
+            {
+                durations[i] = (int) Math.max(1, deltaMs * TIMESCALE / 1000L);
+            }
+        }
+        durations[sampleCount - 1] = durations[sampleCount - 2];
+        return durations;
+    }
+
+    static final class Parsed
+    {
+        byte[] sps;
+        byte[] pps;
+        int[] frameStartIndices;
+        boolean[] keyframes;
+        int nalCount;
+    }
+
+    /** Analyze an Annex B byte stream: extract SPS/PPS bodies and map slice NALs to frame boundaries. */
+    static Parsed analyze(byte[] annexB)
+    {
+        List<AnnexBWriter.Nalu> nalus = AnnexBWriter.splitNalus(annexB);
+        Parsed p = new Parsed();
+        p.nalCount = nalus.size();
+
+        List<Integer> frameStarts = new ArrayList<>();
+        List<Boolean> kf = new ArrayList<>();
+
+        for (int i = 0; i < nalus.size(); i++)
+        {
+            AnnexBWriter.Nalu nal = nalus.get(i);
+            // Start-code scanning can produce false positives when a byte triple
+            // inside a NAL body happens to look like 00 00 01. Skip NALs whose
+            // header fails the forbidden_zero_bit check instead of dying on them.
+            if (nal.length == 0 || (annexB[nal.offset] & 0x80) != 0)
+            {
+                continue;
+            }
+            int type = nal.nalUnitType(annexB);
+            switch (type)
+            {
+                case AnnexBWriter.NAL_TYPE_SPS:
+                    if (p.sps == null)
+                    {
+                        p.sps = slice(annexB, nal.offset, nal.length);
+                    }
+                    break;
+                case AnnexBWriter.NAL_TYPE_PPS:
+                    if (p.pps == null)
+                    {
+                        p.pps = slice(annexB, nal.offset, nal.length);
+                    }
+                    break;
+                case AnnexBWriter.NAL_TYPE_IDR_SLICE:
+                case AnnexBWriter.NAL_TYPE_NON_IDR_SLICE:
+                    // A slice NAL marks the start of a new frame. Preceding parameter NALs
+                    // (SPS/PPS/SEI) in this run belong to this same frame, so walk back.
+                    int frameStart = i;
+                    while (frameStart > 0)
+                    {
+                        AnnexBWriter.Nalu prev = nalus.get(frameStart - 1);
+                        if (prev.length == 0 || (annexB[prev.offset] & 0x80) != 0) break;
+                        int prevType = prev.nalUnitType(annexB);
+                        if (prevType == AnnexBWriter.NAL_TYPE_SPS
+                            || prevType == AnnexBWriter.NAL_TYPE_PPS
+                            || prevType == AnnexBWriter.NAL_TYPE_SEI
+                            || prevType == AnnexBWriter.NAL_TYPE_AUD)
+                        {
+                            if (!frameStarts.isEmpty() && frameStarts.get(frameStarts.size() - 1) >= frameStart - 1)
+                            {
+                                break;
+                            }
+                            frameStart--;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    frameStarts.add(frameStart);
+                    kf.add(type == AnnexBWriter.NAL_TYPE_IDR_SLICE);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        p.frameStartIndices = new int[frameStarts.size()];
+        p.keyframes = new boolean[frameStarts.size()];
+        for (int i = 0; i < frameStarts.size(); i++)
+        {
+            p.frameStartIndices[i] = frameStarts.get(i);
+            p.keyframes[i] = kf.get(i);
+        }
+        return p;
+    }
+
+    /**
+     * Splits a driver-emitted parameter blob into its SPS and PPS NAL
+     * bodies. The blob is in Annex B form (start codes between NALs);
+     * scanning for nal_type bytes would false-positive on payload bytes
+     * inside the SPS (e.g. {@code level_idc = 40} matches the PPS nal_type).
+     */
+    static byte[][] extractSpsPpsFromDriverBlob(byte[] blob)
+    {
+        List<AnnexBWriter.Nalu> nalus = AnnexBWriter.splitNalus(blob);
+        if (nalus.isEmpty())
+        {
+            throw new IllegalStateException("driver SPS/PPS blob contains no NAL units");
+        }
+        byte[] sps = null, pps = null;
+        for (AnnexBWriter.Nalu nal : nalus)
+        {
+            int type = nal.nalUnitType(blob);
+            if (type == AnnexBWriter.NAL_TYPE_SPS && sps == null)
+            {
+                sps = Arrays.copyOfRange(blob, nal.offset, nal.offset + nal.length);
+            }
+            else if (type == AnnexBWriter.NAL_TYPE_PPS && pps == null)
+            {
+                pps = Arrays.copyOfRange(blob, nal.offset, nal.offset + nal.length);
+            }
+        }
+        if (sps == null || pps == null)
+        {
+            throw new IllegalStateException("driver SPS/PPS blob missing SPS (" + (sps == null)
+                + ") or PPS (" + (pps == null) + ") after parsing " + nalus.size() + " NALUs");
+        }
+        return new byte[][] { sps, pps };
+    }
+
+    private static byte[] slice(byte[] src, int offset, int length)
+    {
+        byte[] out = new byte[length];
+        System.arraycopy(src, offset, out, 0, length);
+        return out;
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/MjpegEncoder.java
+++ b/src/main/java/com/osrstracker/video/encode/MjpegEncoder.java
@@ -50,11 +50,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MjpegEncoder implements VideoEncoder
 {
     // Circular buffer configuration
-    private static final int MAX_FRAMES = 300; // 10 seconds at 30 FPS
+    private static final int MAX_FRAMES = 300;
 
-    // Maximum resolution cap (1080p)
-    private static final int MAX_WIDTH = 1920;
-    private static final int MAX_HEIGHT = 1080;
+    // Maximum resolution cap (720p). Trades fullscreen sharpness for a
+    // ~40% drop in per-frame JPEG encode time, which keeps the async
+    // writer inside the 33ms/frame budget on dynamic 30fps content.
+    private static final int MAX_WIDTH = 1280;
+    private static final int MAX_HEIGHT = 720;
 
     // Blur kernel radius
     private static final int BLUR_RADIUS = 15;
@@ -74,7 +76,6 @@ public class MjpegEncoder implements VideoEncoder
     {
         currentJpegQuality = quality > 0 ? quality : 0.5f;
         reset();
-        log.debug("MjpegEncoder started ({}% quality)", (int)(currentJpegQuality * 100));
     }
 
     @Override
@@ -108,8 +109,24 @@ public class MjpegEncoder implements VideoEncoder
     @Override
     public ClipData finalizeClip(long startTime, long endTime)
     {
-        // Snapshot frame data from circular buffer (minimal locked time)
-        List<FrameData> framesToProcess = new ArrayList<>();
+        List<TimestampedFrame> frames = snapshot(startTime, endTime);
+        if (frames.isEmpty())
+        {
+            return null;
+        }
+        List<byte[]> clipFrames = new ArrayList<>(frames.size());
+        long totalSize = 0;
+        for (TimestampedFrame f : frames)
+        {
+            clipFrames.add(f.jpeg);
+            totalSize += f.jpeg.length;
+        }
+        return new ClipData(clipFrames, "application/octet-stream", totalSize);
+    }
+
+    public List<TimestampedFrame> snapshot(long startTime, long endTime)
+    {
+        List<TimestampedFrame> framesToProcess = new ArrayList<>();
 
         synchronized (bufferLock)
         {
@@ -125,19 +142,16 @@ public class MjpegEncoder implements VideoEncoder
 
                 if (timestamp >= startTime && timestamp <= endTime && frame != null)
                 {
-                    framesToProcess.add(new FrameData(frame, blur));
+                    framesToProcess.add(new TimestampedFrame(frame, timestamp, blur));
                 }
             }
         }
 
-        // Process frames outside the lock (apply deferred blur)
-        List<byte[]> clipFrames = new ArrayList<>();
-
-        for (FrameData frameData : framesToProcess)
+        List<TimestampedFrame> out = new ArrayList<>(framesToProcess.size());
+        for (TimestampedFrame tf : framesToProcess)
         {
-            byte[] frame = frameData.frame;
-
-            if (frameData.needsBlur)
+            byte[] frame = tf.jpeg;
+            if (tf.needsBlur)
             {
                 try
                 {
@@ -155,16 +169,23 @@ public class MjpegEncoder implements VideoEncoder
                     log.error("Failed to apply deferred blur to frame", e);
                 }
             }
-            clipFrames.add(frame);
+            out.add(new TimestampedFrame(frame, tf.timestampMs, false));
         }
+        return out;
+    }
 
-        if (clipFrames.isEmpty())
+    public static final class TimestampedFrame
+    {
+        public final byte[] jpeg;
+        public final long timestampMs;
+        public final boolean needsBlur;
+
+        public TimestampedFrame(byte[] jpeg, long timestampMs, boolean needsBlur)
         {
-            return null;
+            this.jpeg = jpeg;
+            this.timestampMs = timestampMs;
+            this.needsBlur = needsBlur;
         }
-
-        long totalSize = clipFrames.stream().mapToInt(f -> f.length).sum();
-        return new ClipData(clipFrames, "application/octet-stream", totalSize);
     }
 
     @Override
@@ -193,23 +214,25 @@ public class MjpegEncoder implements VideoEncoder
 
     private BufferedImage convertRgbaToBufferedImage(ByteBuffer rgbaPixels, int width, int height)
     {
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        rgbaPixels.rewind();
+        int[] argb = new int[width * height];
         int rowBytes = width * 4;
 
         for (int y = 0; y < height; y++)
         {
             int srcRow = (height - 1 - y) * rowBytes;
+            int dstRow = y * width;
             for (int x = 0; x < width; x++)
             {
-                int srcIdx = srcRow + x * 4;
+                int srcIdx = srcRow + (x << 2);
                 int r = rgbaPixels.get(srcIdx) & 0xFF;
                 int g = rgbaPixels.get(srcIdx + 1) & 0xFF;
                 int b = rgbaPixels.get(srcIdx + 2) & 0xFF;
-                image.setRGB(x, y, (r << 16) | (g << 8) | b);
+                argb[dstRow + x] = (r << 16) | (g << 8) | b;
             }
         }
 
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        image.setRGB(0, 0, width, height, argb, 0, width);
         return image;
     }
 
@@ -357,15 +380,4 @@ public class MjpegEncoder implements VideoEncoder
         return output;
     }
 
-    private static class FrameData
-    {
-        final byte[] frame;
-        final boolean needsBlur;
-
-        FrameData(byte[] frame, boolean needsBlur)
-        {
-            this.frame = frame;
-            this.needsBlur = needsBlur;
-        }
-    }
 }

--- a/src/main/java/com/osrstracker/video/encode/MjpegToMp4Tool.java
+++ b/src/main/java/com/osrstracker/video/encode/MjpegToMp4Tool.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Standalone driver: take an MJPEG file, run it through the plugin's
+ * Vulkan H.264 encoder, mux the output to a faststart MP4.
+ *
+ * Usage: MjpegToMp4Tool <input.mjpeg> <output.mp4> [fps=30]
+ *
+ * Requires lwjgl-vulkan and its natives on the runtime classpath and a Vulkan
+ * driver that advertises VK_KHR_video_encode_h264 (verify with vulkaninfo).
+ */
+public final class MjpegToMp4Tool
+{
+    public static void main(String[] args) throws Exception
+    {
+        if (args.length < 2)
+        {
+            System.err.println("usage: MjpegToMp4Tool <input.mjpeg> <output.mp4> [fps]");
+            System.err.println("  fps is inferred from the filename pattern *_<N>fps.mjpeg");
+            System.err.println("  pass explicitly only to override.");
+            System.exit(2);
+        }
+        Path input = Paths.get(args[0]);
+        Path output = Paths.get(args[1]);
+        int fps = args.length > 2 ? Integer.parseInt(args[2]) : inferFpsFromFilename(input);
+
+        System.out.println("=== MJPEG -> Vulkan H.264 -> MP4 ===");
+        System.out.println("input:  " + input.toAbsolutePath() + " (" + Files.size(input) / 1024 + " KiB)");
+        System.out.println("output: " + output.toAbsolutePath());
+        System.out.println("fps:    " + fps);
+
+        long t0 = System.nanoTime();
+
+        byte[] raw = Files.readAllBytes(input);
+        List<byte[]> frames = splitMjpeg(raw);
+        if (frames.isEmpty())
+        {
+            throw new IllegalStateException("No JPEG frames found in MJPEG input");
+        }
+        System.out.println("split:  " + frames.size() + " JPEG frames");
+
+        // --- Initialize Vulkan ---
+        VulkanDevice device = new VulkanDevice();
+        device.initialize();
+        VulkanCapabilities caps = new VulkanCapabilities(device);
+        if (!caps.probe())
+        {
+            throw new IllegalStateException("Vulkan H.264 encode not supported on this device");
+        }
+        System.out.printf("vulkan: %s - H.264 encode available (rate-control modes=0x%x, quality levels=%d)%n",
+            device.getDeviceName(), caps.getSupportedRateControlModes(), caps.getMaxQualityLevels());
+
+        // --- Run the plugin's burst encoder ---
+        byte[] h264;
+        byte[] driverSpsPps;
+        try (VulkanEncoder enc = new VulkanEncoder(device, caps))
+        {
+            long te0 = System.nanoTime();
+            h264 = enc.burstEncode(frames, fps);
+            long teMs = (System.nanoTime() - te0) / 1_000_000;
+            if (h264 == null || h264.length == 0)
+            {
+                throw new IllegalStateException("burstEncode returned empty bitstream");
+            }
+            driverSpsPps = enc.getDriverSpsPps();
+            System.out.printf("encode: %d frames -> %.1f KiB H.264 in %d ms (%.1f fps)%n",
+                frames.size(), h264.length / 1024.0, teMs,
+                frames.size() * 1000.0 / Math.max(teMs, 1));
+        }
+
+        java.awt.image.BufferedImage firstFrame = javax.imageio.ImageIO.read(
+            new java.io.ByteArrayInputStream(frames.get(0)));
+        LocalMp4Writer.write(h264, driverSpsPps,
+            firstFrame.getWidth(), firstFrame.getHeight(), fps, output);
+
+        long totalMs = (System.nanoTime() - t0) / 1_000_000;
+        System.out.printf("wrote:  %s (%d KiB) in %d ms%n",
+            output, Files.size(output) / 1024, totalMs);
+    }
+
+    /**
+     * Parses the FPS from the capture filename. The cloud upload pipeline names
+     * everything {@code <prefix>_<N>fps.mjpeg} so the encoder downstream can be
+     * stateless: fps is in the name, not a side channel.
+     *
+     * @throws IllegalArgumentException if the filename doesn't carry fps info.
+     */
+    static int inferFpsFromFilename(Path path)
+    {
+        String name = path.getFileName().toString();
+        java.util.regex.Matcher m = java.util.regex.Pattern
+            .compile("_(\\d+)fps\\.[^.]+$").matcher(name);
+        if (!m.find())
+        {
+            throw new IllegalArgumentException(
+                "can't infer fps from filename '" + name
+                + "'; expected pattern like 'foo_30fps.mjpeg'. Pass fps explicitly to override.");
+        }
+        int fps = Integer.parseInt(m.group(1));
+        if (fps <= 0 || fps > 240)
+        {
+            throw new IllegalArgumentException("filename-inferred fps out of sane range: " + fps);
+        }
+        return fps;
+    }
+
+    // --- MJPEG split: scan for JPEG SOI (FFD8) ... EOI (FFD9) pairs ---
+    static List<byte[]> splitMjpeg(byte[] data)
+    {
+        List<byte[]> out = new ArrayList<>();
+        int i = 0;
+        while (i < data.length - 1)
+        {
+            if ((data[i] & 0xFF) == 0xFF && (data[i + 1] & 0xFF) == 0xD8)
+            {
+                int start = i;
+                i += 2;
+                while (i < data.length - 1)
+                {
+                    if ((data[i] & 0xFF) == 0xFF && (data[i + 1] & 0xFF) == 0xD9)
+                    {
+                        int end = i + 2;
+                        byte[] frame = new byte[end - start];
+                        System.arraycopy(data, start, frame, 0, frame.length);
+                        out.add(frame);
+                        i = end;
+                        break;
+                    }
+                    i++;
+                }
+            }
+            else
+            {
+                i++;
+            }
+        }
+        return out;
+    }
+
+}

--- a/src/main/java/com/osrstracker/video/encode/Mp4Writer.java
+++ b/src/main/java/com/osrstracker/video/encode/Mp4Writer.java
@@ -1,0 +1,516 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Minimal faststart MP4 muxer for a single H.264/AVC video track.
+ *
+ * Input: complete H.264 bitstream emitted by the GPU encoder (Annex B or AVCC),
+ *        plus SPS and PPS NAL bodies, plus per-frame metadata (keyframe flags,
+ *        presentation timestamps). Everything sits in the ~5-7 MB H.264 output
+ *        range, so we build the entire file in memory and write once.
+ *
+ * Output layout: {@code ftyp | moov | mdat}. {@code moov} before {@code mdat}
+ * is mandatory for browser/Discord/Twitter in-place playback ("faststart").
+ *
+ * Design constraints:
+ * - Zero CPU pressure: integer math + a single streamed write. No transcode.
+ * - Bounded heap: frame metadata is O(samples); bitstream buffers are already
+ *   heap-resident post burst encode.
+ * - One sample per chunk (stsc single entry), 32-bit chunk offsets (stco). Good
+ *   enough for clips up to ~4 GiB; clip target is tens of MB.
+ */
+public final class Mp4Writer
+{
+    /** Per-sample metadata. Units of {@code durationTicks} are in the media timescale. */
+    public static final class Sample
+    {
+        public final int offsetInMdat;   // relative to first AVCC sample
+        public final int size;           // AVCC size (4-byte length prefix + NAL body)
+        public final boolean keyframe;
+        public final int durationTicks;
+
+        public Sample(int offsetInMdat, int size, boolean keyframe, int durationTicks)
+        {
+            this.offsetInMdat = offsetInMdat;
+            this.size = size;
+            this.keyframe = keyframe;
+            this.durationTicks = durationTicks;
+        }
+    }
+
+    private final int width;
+    private final int height;
+    private final int timescale;
+    private final byte[] sps;
+    private final byte[] pps;
+
+    public Mp4Writer(int width, int height, int timescale, byte[] sps, byte[] pps)
+    {
+        if (width <= 0 || height <= 0) throw new IllegalArgumentException("bad dimensions");
+        if (timescale <= 0) throw new IllegalArgumentException("bad timescale");
+        this.width = width;
+        this.height = height;
+        this.timescale = timescale;
+        this.sps = Objects.requireNonNull(sps, "sps").clone();
+        this.pps = Objects.requireNonNull(pps, "pps").clone();
+        if (sps.length < 4) throw new IllegalArgumentException("SPS too short (need profile/level bytes)");
+    }
+
+    /**
+     * Build AVCC samples for the given Annex B bitstream. Returns {@code (avccBytes, samples)}
+     * where {@code avccBytes} is the concatenation of all non-parameter NALs with 4-byte
+     * length prefixes, ready to place in {@code mdat}. SPS/PPS NALs are filtered
+     * out; they live in {@code avcC}, not in sample data.
+     */
+    public static Built buildSamples(byte[] annexBBitstream, int[] frameStartIndices,
+                                     boolean[] keyframeFlags, int[] durationsTicks)
+    {
+        Objects.requireNonNull(annexBBitstream, "annexBBitstream");
+        Objects.requireNonNull(frameStartIndices, "frameStartIndices");
+        if (frameStartIndices.length != keyframeFlags.length || frameStartIndices.length != durationsTicks.length)
+        {
+            throw new IllegalArgumentException("metadata arrays must match frame count");
+        }
+        List<AnnexBWriter.Nalu> nalus = AnnexBWriter.splitNalus(annexBBitstream);
+
+        // Group NALs into frames: nalus[i] belongs to frame k if frameStartIndices[k] <= i < frameStartIndices[k+1].
+        // We emit one AVCC sample per frame (concatenation of its non-parameter NALs with length prefixes).
+        ByteBuffer out = ByteBuffer.allocate(annexBBitstream.length + 8 * nalus.size());
+        List<Sample> samples = new ArrayList<>(frameStartIndices.length);
+
+        for (int f = 0; f < frameStartIndices.length; f++)
+        {
+            int from = frameStartIndices[f];
+            int to = (f + 1 < frameStartIndices.length) ? frameStartIndices[f + 1] : nalus.size();
+            int sampleStart = out.position();
+            for (int i = from; i < to; i++)
+            {
+                AnnexBWriter.Nalu nalu = nalus.get(i);
+                if (nalu.length == 0 || (annexBBitstream[nalu.offset] & 0x80) != 0)
+                {
+                    // False-positive start code inside a NAL body; ignore.
+                    continue;
+                }
+                int type = nalu.nalUnitType(annexBBitstream);
+                if (type == AnnexBWriter.NAL_TYPE_SPS || type == AnnexBWriter.NAL_TYPE_PPS)
+                {
+                    continue;
+                }
+                out.putInt(nalu.length);
+                out.put(annexBBitstream, nalu.offset, nalu.length);
+            }
+            int sampleSize = out.position() - sampleStart;
+            if (sampleSize == 0)
+            {
+                throw new IllegalStateException("frame " + f + " produced no sample data");
+            }
+            samples.add(new Sample(sampleStart, sampleSize, keyframeFlags[f], durationsTicks[f]));
+        }
+
+        byte[] avcc = new byte[out.position()];
+        System.arraycopy(out.array(), 0, avcc, 0, avcc.length);
+        return new Built(avcc, samples);
+    }
+
+    public static final class Built
+    {
+        public final byte[] avccBitstream;
+        public final List<Sample> samples;
+
+        Built(byte[] avccBitstream, List<Sample> samples)
+        {
+            this.avccBitstream = avccBitstream;
+            this.samples = samples;
+        }
+    }
+
+    /** Write the MP4 file to {@code path}. Overwrites any existing file. */
+    public void writeTo(Path path, byte[] avccBitstream, List<Sample> samples) throws IOException
+    {
+        Objects.requireNonNull(path, "path");
+        byte[] ftyp = buildFtyp();
+        byte[] moov = buildMoov(samples, /* mdatPayloadStart */ 0); // fixup offsets below once mdat position is known
+        int headerSize = ftyp.length + moov.length;
+        int mdatPayloadStart = headerSize + 8; // past mdat's own size+type
+        moov = buildMoov(samples, mdatPayloadStart);
+        int mdatBoxSize = 8 + avccBitstream.length;
+
+        try (FileChannel ch = FileChannel.open(path,
+            StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE))
+        {
+            ch.write(ByteBuffer.wrap(ftyp));
+            ch.write(ByteBuffer.wrap(moov));
+            ByteBuffer mdat = ByteBuffer.allocate(8);
+            mdat.putInt(mdatBoxSize);
+            mdat.putInt(0x6D646174); // 'mdat'
+            mdat.flip();
+            ch.write(mdat);
+            ch.write(ByteBuffer.wrap(avccBitstream));
+        }
+    }
+
+    /** Convenience: also exposes the final MP4 as a byte[] (tests and small clips). */
+    public byte[] writeToBytes(byte[] avccBitstream, List<Sample> samples)
+    {
+        byte[] ftyp = buildFtyp();
+        byte[] moovProbe = buildMoov(samples, 0);
+        int headerSize = ftyp.length + moovProbe.length;
+        int mdatPayloadStart = headerSize + 8;
+        byte[] moov = buildMoov(samples, mdatPayloadStart);
+        int mdatBoxSize = 8 + avccBitstream.length;
+        int total = ftyp.length + moov.length + mdatBoxSize;
+
+        ByteBuffer buf = ByteBuffer.allocate(total);
+        buf.put(ftyp);
+        buf.put(moov);
+        buf.putInt(mdatBoxSize);
+        buf.putInt(0x6D646174);
+        buf.put(avccBitstream);
+        return buf.array();
+    }
+
+    private byte[] buildFtyp()
+    {
+        // ftyp: major_brand='isom', minor_version=512, compatible_brands=['isom','iso2','avc1','mp41']
+        BoxBuilder b = new BoxBuilder("ftyp");
+        b.writeFourCC("isom");
+        b.writeInt(512);
+        b.writeFourCC("isom");
+        b.writeFourCC("iso2");
+        b.writeFourCC("avc1");
+        b.writeFourCC("mp41");
+        return b.build();
+    }
+
+    private byte[] buildMoov(List<Sample> samples, int mdatPayloadStart)
+    {
+        long totalDuration = 0;
+        for (Sample s : samples) totalDuration += s.durationTicks;
+
+        BoxBuilder moov = new BoxBuilder("moov");
+        moov.writeBytes(buildMvhd(totalDuration));
+        moov.writeBytes(buildTrak(samples, totalDuration, mdatPayloadStart));
+        return moov.build();
+    }
+
+    private byte[] buildMvhd(long duration)
+    {
+        BoxBuilder b = new BoxBuilder("mvhd");
+        b.writeInt(0);                          // version + flags
+        b.writeInt(0);                          // creation_time
+        b.writeInt(0);                          // modification_time
+        b.writeInt(timescale);                  // timescale
+        b.writeInt((int) duration);             // duration
+        b.writeInt(0x00010000);                 // rate 1.0
+        b.writeShort((short) 0x0100);           // volume 1.0
+        b.writeShort((short) 0);                // reserved
+        b.writeInt(0); b.writeInt(0);           // reserved[2]
+        writeUnityMatrix(b);                    // 9x int32 matrix
+        for (int i = 0; i < 6; i++) b.writeInt(0); // pre_defined[6]
+        b.writeInt(2);                          // next_track_ID
+        return b.build();
+    }
+
+    private byte[] buildTrak(List<Sample> samples, long totalDuration, int mdatPayloadStart)
+    {
+        BoxBuilder trak = new BoxBuilder("trak");
+        trak.writeBytes(buildTkhd(totalDuration));
+        trak.writeBytes(buildMdia(samples, totalDuration, mdatPayloadStart));
+        return trak.build();
+    }
+
+    private byte[] buildTkhd(long duration)
+    {
+        BoxBuilder b = new BoxBuilder("tkhd");
+        b.writeInt(0x0000000F);                 // version=0, flags: enabled|in_movie|in_preview|in_poster
+        b.writeInt(0);                          // creation_time
+        b.writeInt(0);                          // modification_time
+        b.writeInt(1);                          // track_ID
+        b.writeInt(0);                          // reserved
+        b.writeInt((int) duration);             // duration
+        b.writeInt(0); b.writeInt(0);           // reserved[2]
+        b.writeShort((short) 0);                // layer
+        b.writeShort((short) 0);                // alternate_group
+        b.writeShort((short) 0);                // volume (0 for non-audio)
+        b.writeShort((short) 0);                // reserved
+        writeUnityMatrix(b);
+        b.writeInt(width << 16);                // width 16.16 fixed
+        b.writeInt(height << 16);               // height
+        return b.build();
+    }
+
+    private byte[] buildMdia(List<Sample> samples, long duration, int mdatPayloadStart)
+    {
+        BoxBuilder mdia = new BoxBuilder("mdia");
+        mdia.writeBytes(buildMdhd(duration));
+        mdia.writeBytes(buildHdlr());
+        mdia.writeBytes(buildMinf(samples, mdatPayloadStart));
+        return mdia.build();
+    }
+
+    private byte[] buildMdhd(long duration)
+    {
+        BoxBuilder b = new BoxBuilder("mdhd");
+        b.writeInt(0);                          // version + flags
+        b.writeInt(0);                          // creation
+        b.writeInt(0);                          // modification
+        b.writeInt(timescale);
+        b.writeInt((int) duration);
+        b.writeShort((short) 0x55C4);           // 'und' packed language
+        b.writeShort((short) 0);                // pre_defined
+        return b.build();
+    }
+
+    private byte[] buildHdlr()
+    {
+        BoxBuilder b = new BoxBuilder("hdlr");
+        b.writeInt(0);                          // version + flags
+        b.writeInt(0);                          // pre_defined
+        b.writeFourCC("vide");
+        b.writeInt(0); b.writeInt(0); b.writeInt(0); // reserved[3]
+        b.writeBytes(new byte[] { 'V','i','d','e','o','H','a','n','d','l','e','r', 0 });
+        return b.build();
+    }
+
+    private byte[] buildMinf(List<Sample> samples, int mdatPayloadStart)
+    {
+        BoxBuilder minf = new BoxBuilder("minf");
+        minf.writeBytes(buildVmhd());
+        minf.writeBytes(buildDinf());
+        minf.writeBytes(buildStbl(samples, mdatPayloadStart));
+        return minf.build();
+    }
+
+    private byte[] buildVmhd()
+    {
+        BoxBuilder b = new BoxBuilder("vmhd");
+        b.writeInt(1);                          // version=0, flags=1
+        b.writeShort((short) 0);                // graphicsmode
+        b.writeShort((short) 0); b.writeShort((short) 0); b.writeShort((short) 0); // opcolor
+        return b.build();
+    }
+
+    private byte[] buildDinf()
+    {
+        BoxBuilder dinf = new BoxBuilder("dinf");
+        BoxBuilder dref = new BoxBuilder("dref");
+        dref.writeInt(0);                       // version + flags
+        dref.writeInt(1);                       // entry_count
+        BoxBuilder url = new BoxBuilder("url ");
+        url.writeInt(1);                        // flags: self-contained
+        dref.writeBytes(url.build());
+        dinf.writeBytes(dref.build());
+        return dinf.build();
+    }
+
+    private byte[] buildStbl(List<Sample> samples, int mdatPayloadStart)
+    {
+        BoxBuilder stbl = new BoxBuilder("stbl");
+        stbl.writeBytes(buildStsd());
+        stbl.writeBytes(buildStts(samples));
+        stbl.writeBytes(buildStss(samples));
+        stbl.writeBytes(buildStsc(samples.size()));
+        stbl.writeBytes(buildStsz(samples));
+        stbl.writeBytes(buildStco(samples, mdatPayloadStart));
+        return stbl.build();
+    }
+
+    private byte[] buildStsd()
+    {
+        BoxBuilder stsd = new BoxBuilder("stsd");
+        stsd.writeInt(0);                       // version + flags
+        stsd.writeInt(1);                       // entry_count
+
+        BoxBuilder avc1 = new BoxBuilder("avc1");
+        for (int i = 0; i < 6; i++) avc1.writeByte((byte) 0); // reserved
+        avc1.writeShort((short) 1);             // data_reference_index
+        avc1.writeShort((short) 0); avc1.writeShort((short) 0); // pre_defined, reserved
+        avc1.writeInt(0); avc1.writeInt(0); avc1.writeInt(0); // pre_defined[3]
+        avc1.writeShort((short) width);
+        avc1.writeShort((short) height);
+        avc1.writeInt(0x00480000);              // horizresolution 72
+        avc1.writeInt(0x00480000);              // vertresolution 72
+        avc1.writeInt(0);                       // reserved
+        avc1.writeShort((short) 1);             // frame_count
+        byte[] compressor = new byte[32];       // compressorname[32], pascal-style
+        avc1.writeBytes(compressor);
+        avc1.writeShort((short) 0x0018);        // depth
+        avc1.writeShort((short) -1);            // pre_defined
+        avc1.writeBytes(buildAvcC());
+        avc1.writeBytes(buildColr());
+        stsd.writeBytes(avc1.build());
+        return stsd.build();
+    }
+
+    // nclx colr: redundant with the SPS VUI but written as belt-and-suspenders,
+    // matching libx264's habit. matrix=6 (BT.601), full_range=1.
+    private static byte[] buildColr()
+    {
+        BoxBuilder b = new BoxBuilder("colr");
+        b.writeFourCC("nclx");
+        b.writeShort((short) 2);      // colour_primaries unspecified
+        b.writeShort((short) 2);      // transfer_characteristics unspecified
+        b.writeShort((short) 6);      // matrix_coefficients = BT.601
+        b.writeByte((byte) 0x80);     // full_range_flag=1, reserved=0
+        return b.build();
+    }
+
+    private byte[] buildAvcC()
+    {
+        // ISO/IEC 14496-15 section 5.2.4.1 AVCDecoderConfigurationRecord
+        BoxBuilder b = new BoxBuilder("avcC");
+        b.writeByte((byte) 1);                          // configurationVersion
+        b.writeByte(sps[1]);                            // AVCProfileIndication
+        b.writeByte(sps[2]);                            // profile_compatibility
+        b.writeByte(sps[3]);                            // AVCLevelIndication
+        b.writeByte((byte) 0xFF);                       // reserved(6)=111111b | lengthSizeMinusOne(2)=11
+        b.writeByte((byte) 0xE1);                       // reserved(3)=111b | numOfSequenceParameterSets(5)=1
+        b.writeShort((short) sps.length);
+        b.writeBytes(sps);
+        b.writeByte((byte) 1);                          // numOfPictureParameterSets
+        b.writeShort((short) pps.length);
+        b.writeBytes(pps);
+        return b.build();
+    }
+
+    private byte[] buildStts(List<Sample> samples)
+    {
+        // Run-length encode equal-duration runs
+        List<int[]> runs = new ArrayList<>();
+        int count = 0;
+        int curDur = -1;
+        for (Sample s : samples)
+        {
+            if (s.durationTicks == curDur)
+            {
+                count++;
+            }
+            else
+            {
+                if (count > 0) runs.add(new int[] { count, curDur });
+                count = 1;
+                curDur = s.durationTicks;
+            }
+        }
+        if (count > 0) runs.add(new int[] { count, curDur });
+
+        BoxBuilder b = new BoxBuilder("stts");
+        b.writeInt(0);                          // version + flags
+        b.writeInt(runs.size());
+        for (int[] r : runs)
+        {
+            b.writeInt(r[0]);
+            b.writeInt(r[1]);
+        }
+        return b.build();
+    }
+
+    private byte[] buildStss(List<Sample> samples)
+    {
+        List<Integer> keyframes = new ArrayList<>();
+        for (int i = 0; i < samples.size(); i++)
+        {
+            if (samples.get(i).keyframe) keyframes.add(i + 1);
+        }
+        BoxBuilder b = new BoxBuilder("stss");
+        b.writeInt(0);
+        b.writeInt(keyframes.size());
+        for (int k : keyframes) b.writeInt(k);
+        return b.build();
+    }
+
+    private byte[] buildStsc(int sampleCount)
+    {
+        BoxBuilder b = new BoxBuilder("stsc");
+        b.writeInt(0);                          // version + flags
+        b.writeInt(1);                          // entry_count: single run, 1 sample per chunk
+        b.writeInt(1);                          // first_chunk
+        b.writeInt(1);                          // samples_per_chunk
+        b.writeInt(1);                          // sample_description_index
+        return b.build();
+    }
+
+    private byte[] buildStsz(List<Sample> samples)
+    {
+        BoxBuilder b = new BoxBuilder("stsz");
+        b.writeInt(0);                          // version + flags
+        b.writeInt(0);                          // sample_size=0 (per-sample sizes follow)
+        b.writeInt(samples.size());
+        for (Sample s : samples) b.writeInt(s.size);
+        return b.build();
+    }
+
+    private byte[] buildStco(List<Sample> samples, int mdatPayloadStart)
+    {
+        BoxBuilder b = new BoxBuilder("stco");
+        b.writeInt(0);
+        b.writeInt(samples.size());
+        for (Sample s : samples) b.writeInt(mdatPayloadStart + s.offsetInMdat);
+        return b.build();
+    }
+
+    private static void writeUnityMatrix(BoxBuilder b)
+    {
+        int[] m = { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 };
+        for (int v : m) b.writeInt(v);
+    }
+
+    private static final class BoxBuilder
+    {
+        private final String fourcc;
+        private final java.io.ByteArrayOutputStream buf = new java.io.ByteArrayOutputStream();
+
+        BoxBuilder(String fourcc)
+        {
+            if (fourcc.length() != 4) throw new IllegalArgumentException("fourcc must be 4 chars");
+            this.fourcc = fourcc;
+        }
+
+        void writeByte(byte v) { buf.write(v & 0xFF); }
+        void writeShort(short v)
+        {
+            buf.write((v >>> 8) & 0xFF);
+            buf.write(v & 0xFF);
+        }
+        void writeInt(int v)
+        {
+            buf.write((v >>> 24) & 0xFF);
+            buf.write((v >>> 16) & 0xFF);
+            buf.write((v >>>  8) & 0xFF);
+            buf.write(v & 0xFF);
+        }
+        void writeFourCC(String s)
+        {
+            if (s.length() != 4) throw new IllegalArgumentException();
+            for (int i = 0; i < 4; i++) buf.write(s.charAt(i) & 0x7F);
+        }
+        void writeBytes(byte[] b)
+        {
+            try { buf.write(b); } catch (IOException e) { throw new AssertionError(e); }
+        }
+
+        byte[] build()
+        {
+            byte[] body = buf.toByteArray();
+            int size = body.length + 8;
+            ByteBuffer out = ByteBuffer.allocate(size);
+            out.putInt(size);
+            for (int i = 0; i < 4; i++) out.put((byte) fourcc.charAt(i));
+            out.put(body);
+            return out.array();
+        }
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/Nv12Converter.java
+++ b/src/main/java/com/osrstracker/video/encode/Nv12Converter.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import java.nio.ByteBuffer;
+
+/**
+ * RGB to NV12 (YCbCr 4:2:0, biplanar) colour conversion.
+ *
+ * NV12 layout for a W x H image:
+ *   - Plane 0 (Y, luma): W*H bytes, one per pixel.
+ *   - Plane 1 (UV, chroma): (W/2)*(H/2) interleaved pairs = (W/2)*(H/2)*2 bytes.
+ *     Each pair covers a 2x2 pixel block; order is [U, V].
+ *
+ * Conversion uses BT.601 full-range (JFIF). Full dynamic range is signalled
+ * end-to-end via the SPS VUI (video_full_range_flag=1, matrix=6) and backed
+ * up by the MP4 colr atom, matching what libx264 produces for -pix_fmt
+ * yuvj420p. Decoders read the SPS VUI first, so any compliant player renders
+ * 1:1 with the source RGB regardless of container metadata.
+ *
+ * BT.601 JFIF matrix:
+ *   Y  =  0.299 R + 0.587 G + 0.114 B
+ *   Cb = 128 - 0.168736 R - 0.331264 G + 0.5 B
+ *   Cr = 128 + 0.5 R - 0.418688 G - 0.081312 B
+ *
+ * Width and height must be even. Callers pad the frame up to multiples of 2
+ * (or 16 for H.264 macroblocks) before calling this.
+ */
+public final class Nv12Converter
+{
+    private Nv12Converter() {}
+
+    /**
+     * Converts ARGB pixels (as returned by {@code BufferedImage.getRGB}) to NV12.
+     *
+     * @param argb      WxH ARGB int pixels, row-major.
+     * @param width     Must be even.
+     * @param height    Must be even.
+     * @param yOut      Target buffer for the Y plane. Must hold at least {@code width*height} bytes.
+     * @param yOffset   Offset into {@code yOut} to start writing the Y plane.
+     * @param uvOut     Target buffer for the interleaved UV plane. Must hold at least
+     *                  {@code width*height/2} bytes.
+     * @param uvOffset  Offset into {@code uvOut} to start writing the UV plane.
+     */
+    public static void argbToNv12(int[] argb, int width, int height,
+                                  byte[] yOut, int yOffset,
+                                  byte[] uvOut, int uvOffset)
+    {
+        if (width <= 0 || height <= 0) throw new IllegalArgumentException("non-positive dimensions");
+        if ((width & 1) != 0 || (height & 1) != 0)
+        {
+            throw new IllegalArgumentException("width and height must be even for NV12 (got "
+                + width + "x" + height + ")");
+        }
+        int pixels = width * height;
+        if (argb.length < pixels) throw new IllegalArgumentException("argb too small");
+        if (yOut.length - yOffset < pixels)
+            throw new IllegalArgumentException("yOut too small");
+        if (uvOut.length - uvOffset < pixels / 2)
+            throw new IllegalArgumentException("uvOut too small");
+
+        // Walk 2x2 blocks so we can compute Y for every pixel and one averaged
+        // Cb/Cr per block.
+        for (int y = 0; y < height; y += 2)
+        {
+            int rowBase0 = y * width;
+            int rowBase1 = (y + 1) * width;
+            for (int x = 0; x < width; x += 2)
+            {
+                int p00 = argb[rowBase0 + x];
+                int p01 = argb[rowBase0 + x + 1];
+                int p10 = argb[rowBase1 + x];
+                int p11 = argb[rowBase1 + x + 1];
+
+                // Y for each of the four pixels.
+                int y00 = rgbToY(p00);
+                int y01 = rgbToY(p01);
+                int y10 = rgbToY(p10);
+                int y11 = rgbToY(p11);
+
+                yOut[yOffset + rowBase0 + x]     = (byte) y00;
+                yOut[yOffset + rowBase0 + x + 1] = (byte) y01;
+                yOut[yOffset + rowBase1 + x]     = (byte) y10;
+                yOut[yOffset + rowBase1 + x + 1] = (byte) y11;
+
+                // Box-filter the 2x2 block for the chroma sample. Hardware encoders
+                // apply their own internal filter on top.
+                int r = ((p00 >> 16) & 0xFF) + ((p01 >> 16) & 0xFF) + ((p10 >> 16) & 0xFF) + ((p11 >> 16) & 0xFF);
+                int g = ((p00 >>  8) & 0xFF) + ((p01 >>  8) & 0xFF) + ((p10 >>  8) & 0xFF) + ((p11 >>  8) & 0xFF);
+                int b = ( p00        & 0xFF) + ( p01        & 0xFF) + ( p10        & 0xFF) + ( p11        & 0xFF);
+                r >>= 2; g >>= 2; b >>= 2;
+
+                int cb = clamp((-43 * r - 85 * g + 128 * b + 32768) >> 8, 0, 255);
+                int cr = clamp(( 128 * r - 107 * g - 21 * b + 32768) >> 8, 0, 255);
+
+                int uvIndex = uvOffset + (y / 2) * width + x;
+                uvOut[uvIndex]     = (byte) cb;
+                uvOut[uvIndex + 1] = (byte) cr;
+            }
+        }
+    }
+
+    /**
+     * Writes Y then interleaved UV contiguously into {@code out} at its current
+     * position, advancing it by {@code width*height*3/2}. Used on the encode
+     * hot path to write directly into mapped GPU staging memory.
+     */
+    public static void argbToNv12(int[] argb, int width, int height, ByteBuffer out)
+    {
+        if (width <= 0 || height <= 0) throw new IllegalArgumentException("non-positive dimensions");
+        if ((width & 1) != 0 || (height & 1) != 0)
+        {
+            throw new IllegalArgumentException("width and height must be even for NV12 (got "
+                + width + "x" + height + ")");
+        }
+        int pixels = width * height;
+        if (argb.length < pixels) throw new IllegalArgumentException("argb too small");
+        int nv12Bytes = pixels + pixels / 2;
+        int yBase = out.position();
+        int uvBase = yBase + pixels;
+        if (out.limit() - yBase < nv12Bytes)
+            throw new IllegalArgumentException("out too small: need " + nv12Bytes
+                + " bytes, have " + (out.limit() - yBase));
+
+        for (int y = 0; y < height; y += 2)
+        {
+            int rowBase0 = y * width;
+            int rowBase1 = (y + 1) * width;
+            for (int x = 0; x < width; x += 2)
+            {
+                int p00 = argb[rowBase0 + x];
+                int p01 = argb[rowBase0 + x + 1];
+                int p10 = argb[rowBase1 + x];
+                int p11 = argb[rowBase1 + x + 1];
+
+                out.put(yBase + rowBase0 + x,     (byte) rgbToY(p00));
+                out.put(yBase + rowBase0 + x + 1, (byte) rgbToY(p01));
+                out.put(yBase + rowBase1 + x,     (byte) rgbToY(p10));
+                out.put(yBase + rowBase1 + x + 1, (byte) rgbToY(p11));
+
+                int r = ((p00 >> 16) & 0xFF) + ((p01 >> 16) & 0xFF) + ((p10 >> 16) & 0xFF) + ((p11 >> 16) & 0xFF);
+                int g = ((p00 >>  8) & 0xFF) + ((p01 >>  8) & 0xFF) + ((p10 >>  8) & 0xFF) + ((p11 >>  8) & 0xFF);
+                int b = ( p00        & 0xFF) + ( p01        & 0xFF) + ( p10        & 0xFF) + ( p11        & 0xFF);
+                r >>= 2; g >>= 2; b >>= 2;
+
+                int cb = clamp((-43 * r - 85 * g + 128 * b + 32768) >> 8, 0, 255);
+                int cr = clamp(( 128 * r - 107 * g - 21 * b + 32768) >> 8, 0, 255);
+
+                int uvIndex = uvBase + (y / 2) * width + x;
+                out.put(uvIndex,     (byte) cb);
+                out.put(uvIndex + 1, (byte) cr);
+            }
+        }
+        out.position(yBase + nv12Bytes);
+    }
+
+    /**
+     * Convenience: allocates the output buffers and returns them as a pair.
+     * {@link #argbToNv12} is preferred on hot paths (no allocation).
+     */
+    public static Nv12Frame argbToNv12(int[] argb, int width, int height)
+    {
+        byte[] y = new byte[width * height];
+        byte[] uv = new byte[width * height / 2];
+        argbToNv12(argb, width, height, y, 0, uv, 0);
+        return new Nv12Frame(y, uv, width, height);
+    }
+
+    /** Container for an NV12-converted frame. */
+    public static final class Nv12Frame
+    {
+        public final byte[] y;
+        public final byte[] uv;
+        public final int width;
+        public final int height;
+
+        public Nv12Frame(byte[] y, byte[] uv, int width, int height)
+        {
+            this.y = y;
+            this.uv = uv;
+            this.width = width;
+            this.height = height;
+        }
+    }
+
+    // --- Per-pixel BT.601 full-range (JFIF), integer-math, avoid doubles on hot path.
+
+    private static int rgbToY(int argb)
+    {
+        int r = (argb >> 16) & 0xFF;
+        int g = (argb >>  8) & 0xFF;
+        int b =  argb        & 0xFF;
+        // Y = 0.299 R + 0.587 G + 0.114 B. Fixed-point *256 -> {77, 150, 29} (sum 256).
+        return clamp((77 * r + 150 * g + 29 * b + 128) >> 8, 0, 255);
+    }
+
+    private static int clamp(int v, int lo, int hi)
+    {
+        return v < lo ? lo : (v > hi ? hi : v);
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/VulkanBarriers.java
+++ b/src/main/java/com/osrstracker/video/encode/VulkanBarriers.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, Dennis De Vulder
+ * All rights reserved. See VulkanEncoder.java for full license text.
+ */
+package com.osrstracker.video.encode;
+
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.*;
+
+import static org.lwjgl.vulkan.VK10.VK_IMAGE_ASPECT_COLOR_BIT;
+import static org.lwjgl.vulkan.VK13.*;
+
+/**
+ * Synchronization2 barrier helpers. All methods are stateless; the caller
+ * supplies the command buffer to record into.
+ *
+ * For a queue-family ownership transfer, the release barrier issued on the
+ * source queue and the acquire barrier issued on the target queue must match
+ * on layout and on {@code srcQueueFamilyIndex} / {@code dstQueueFamilyIndex}.
+ */
+final class VulkanBarriers
+{
+    private VulkanBarriers() {}
+
+    /** Single-layer image barrier, records into {@code cmd}. */
+    static void image(MemoryStack stack, VkCommandBuffer cmd, long image,
+                      int oldLayout, int newLayout,
+                      int srcAccess, int dstAccess,
+                      int srcStage, int dstStage,
+                      int arrayLayer,
+                      int srcQueueFamily, int dstQueueFamily)
+    {
+        image(stack, cmd, image, oldLayout, newLayout,
+            srcAccess, dstAccess, srcStage, dstStage, arrayLayer,
+            0L, 0L, srcQueueFamily, dstQueueFamily);
+    }
+
+    /**
+     * Overload for access/stage masks that only fit in 64-bit (e.g.
+     * {@code VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR}). Pass {@code 0L}
+     * to fall back to the 32-bit {@code dstAccess} / {@code dstStage}
+     * arguments.
+     */
+    static void image(MemoryStack stack, VkCommandBuffer cmd, long image,
+                      int oldLayout, int newLayout,
+                      int srcAccess, int dstAccess,
+                      int srcStage, int dstStage,
+                      int arrayLayer,
+                      long dstAccess64, long dstStage64,
+                      int srcQueueFamily, int dstQueueFamily)
+    {
+        long finalDstAccess = dstAccess64 != 0 ? dstAccess64 : dstAccess;
+        long finalDstStage  = dstStage64 != 0 ? dstStage64
+            : (dstStage != 0 ? dstStage : VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+        long finalSrcStage  = srcStage != 0 ? srcStage : VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+
+        VkImageMemoryBarrier2.Buffer barrier = VkImageMemoryBarrier2.calloc(1, stack)
+            .sType(VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2)
+            .srcStageMask(finalSrcStage)
+            .srcAccessMask(srcAccess)
+            .dstStageMask(finalDstStage)
+            .dstAccessMask(finalDstAccess)
+            .oldLayout(oldLayout)
+            .newLayout(newLayout)
+            .srcQueueFamilyIndex(srcQueueFamily)
+            .dstQueueFamilyIndex(dstQueueFamily)
+            .image(image)
+            .subresourceRange(r -> r
+                .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
+                .baseMipLevel(0)
+                .levelCount(1)
+                .baseArrayLayer(arrayLayer)
+                .layerCount(1));
+
+        VkDependencyInfo depInfo = VkDependencyInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_DEPENDENCY_INFO)
+            .pImageMemoryBarriers(barrier);
+
+        vkCmdPipelineBarrier2(cmd, depInfo);
+    }
+
+    /** Full-range buffer barrier, records into {@code cmd}. */
+    static void buffer(MemoryStack stack, VkCommandBuffer cmd, long buffer, long size,
+                       long srcAccess, long dstAccess,
+                       long srcStage, long dstStage)
+    {
+        VkBufferMemoryBarrier2.Buffer barrier = VkBufferMemoryBarrier2.calloc(1, stack)
+            .sType(VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2)
+            .srcStageMask(srcStage)
+            .srcAccessMask(srcAccess)
+            .dstStageMask(dstStage)
+            .dstAccessMask(dstAccess)
+            .buffer(buffer)
+            .offset(0)
+            .size(size);
+
+        VkDependencyInfo depInfo = VkDependencyInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_DEPENDENCY_INFO)
+            .pBufferMemoryBarriers(barrier);
+
+        vkCmdPipelineBarrier2(cmd, depInfo);
+    }
+}

--- a/src/main/java/com/osrstracker/video/encode/VulkanCapabilities.java
+++ b/src/main/java/com/osrstracker/video/encode/VulkanCapabilities.java
@@ -32,7 +32,7 @@ import org.lwjgl.vulkan.*;
 import java.nio.IntBuffer;
 
 import static org.lwjgl.system.MemoryStack.stackPush;
-import static org.lwjgl.vulkan.EXTVideoEncodeH264.*;
+import static org.lwjgl.vulkan.KHRVideoEncodeH264.*;
 import static org.lwjgl.vulkan.video.STDVulkanVideoCodecH264.*;
 import static org.lwjgl.vulkan.KHRVideoEncodeQueue.*;
 import static org.lwjgl.vulkan.KHRVideoQueue.*;
@@ -54,6 +54,8 @@ public class VulkanCapabilities
     private int maxQualityLevels;
     private int supportedRateControlModes;
     private int pictureFormat = VK_FORMAT_UNDEFINED;
+    private int h264MaxLevelIdc;
+    private int h264StdSyntaxFlags;
 
     public VulkanCapabilities(VulkanDevice vulkanDevice)
     {
@@ -61,18 +63,30 @@ public class VulkanCapabilities
     }
 
     /**
-     * Builds the H.264 Baseline video profile on the given stack.
+     * Builds the H.264 High profile descriptor.
+     *
+     * Chain order: VkVideoProfileInfoKHR -> VkVideoEncodeUsageInfoKHR ->
+     * VkVideoEncodeH264ProfileInfoKHR. Usage info must come before the codec
+     * profile info; otherwise some drivers pick a default rate-control path
+     * that ignores bitrate targets.
      */
     public VkVideoProfileInfoKHR buildVideoProfile(MemoryStack stack)
     {
-        VkVideoEncodeH264ProfileInfoEXT h264Profile = VkVideoEncodeH264ProfileInfoEXT.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT)
-            .stdProfileIdc(STD_VIDEO_H264_PROFILE_IDC_BASELINE);
+        VkVideoEncodeH264ProfileInfoKHR h264Profile = VkVideoEncodeH264ProfileInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR)
+            .stdProfileIdc(STD_VIDEO_H264_PROFILE_IDC_HIGH);
+
+        VkVideoEncodeUsageInfoKHR usageInfo = VkVideoEncodeUsageInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR)
+            .pNext(h264Profile.address())
+            .videoUsageHints(VK_VIDEO_ENCODE_USAGE_RECORDING_BIT_KHR)
+            .videoContentHints(VK_VIDEO_ENCODE_CONTENT_RENDERED_BIT_KHR)
+            .tuningMode(VK_VIDEO_ENCODE_TUNING_MODE_HIGH_QUALITY_KHR);
 
         return VkVideoProfileInfoKHR.calloc(stack)
             .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR)
-            .pNext(h264Profile)
-            .videoCodecOperation(VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT)
+            .pNext(usageInfo.address())
+            .videoCodecOperation(VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR)
             .chromaSubsampling(VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR)
             .lumaBitDepth(VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR)
             .chromaBitDepth(VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR);
@@ -89,8 +103,8 @@ public class VulkanCapabilities
             VkPhysicalDevice physDevice = vulkanDevice.getPhysicalDevice();
             VkVideoProfileInfoKHR videoProfile = buildVideoProfile(stack);
 
-            VkVideoEncodeH264CapabilitiesEXT h264Caps = VkVideoEncodeH264CapabilitiesEXT.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT);
+            VkVideoEncodeH264CapabilitiesKHR h264Caps = VkVideoEncodeH264CapabilitiesKHR.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR);
 
             VkVideoEncodeCapabilitiesKHR encodeCaps = VkVideoEncodeCapabilitiesKHR.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR)
@@ -98,7 +112,7 @@ public class VulkanCapabilities
 
             VkVideoCapabilitiesKHR videoCaps = VkVideoCapabilitiesKHR.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR)
-                .pNext(encodeCaps);
+                .pNext(encodeCaps.address());
 
             int result = vkGetPhysicalDeviceVideoCapabilitiesKHR(physDevice, videoProfile, videoCaps);
             if (result != VK_SUCCESS)
@@ -113,11 +127,17 @@ public class VulkanCapabilities
             maxActiveReferencePictures = videoCaps.maxActiveReferencePictures();
             maxQualityLevels = encodeCaps.maxQualityLevels();
             supportedRateControlModes = encodeCaps.rateControlModes();
+            h264MaxLevelIdc = h264Caps.maxLevelIdc();
+            h264StdSyntaxFlags = h264Caps.stdSyntaxFlags();
             pictureFormat = querySupportedFormat(physDevice, videoProfile, stack);
 
-            log.debug("Vulkan H.264 encode: {}x{}, {} DPB slots, {} refs, {} quality levels, format={}",
+            log.info("Vulkan H.264 encode caps: {}x{}, {} DPB slots, {} refs, {} quality levels, "
+                + "maxLevelIdc={}, stdSyntaxFlags=0x{}, rcModes=0x{}, format={}",
                 maxWidth, maxHeight, maxDpbSlots, maxActiveReferencePictures,
-                maxQualityLevels, pictureFormat);
+                maxQualityLevels, h264MaxLevelIdc,
+                Integer.toHexString(h264StdSyntaxFlags),
+                Integer.toHexString(supportedRateControlModes),
+                pictureFormat);
 
             return true;
         }

--- a/src/main/java/com/osrstracker/video/encode/VulkanDevice.java
+++ b/src/main/java/com/osrstracker/video/encode/VulkanDevice.java
@@ -33,8 +33,9 @@ import java.nio.IntBuffer;
 
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
-import static org.lwjgl.vulkan.EXTVideoEncodeH264.*;
+import static org.lwjgl.vulkan.KHRVideoEncodeH264.*;
 import static org.lwjgl.vulkan.KHRVideoEncodeQueue.*;
+import static org.lwjgl.vulkan.KHRVideoMaintenance1.*;
 import static org.lwjgl.vulkan.KHRVideoQueue.*;
 import static org.lwjgl.vulkan.VK10.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -52,13 +53,33 @@ public class VulkanDevice implements AutoCloseable
     private VkDevice device;
     private VkQueue videoEncodeQueue;
     private int videoEncodeQueueFamily = -1;
+    /**
+     * A queue family exposing GRAPHICS | COMPUTE | TRANSFER. Required because
+     * {@code vkCmdCopyBufferToImage} (used to upload the NV12 frame) is not a
+     * legal operation on a video-encode-only queue. Host-side frames upload
+     * here, then queue-family-ownership-transfer to the encode queue.
+     */
+    private VkQueue graphicsQueue;
+    private int graphicsQueueFamily = -1;
     private String deviceName = "unknown";
     private boolean closed = false;
 
     private static final String[] REQUIRED_DEVICE_EXTENSIONS = {
         VK_KHR_VIDEO_QUEUE_EXTENSION_NAME,
         VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME,
-        VK_EXT_VIDEO_ENCODE_H264_EXTENSION_NAME,
+        // VUID-vkCreateDevice-ppEnabledExtensionNames-01387: required
+        // transitively by video_encode_queue.
+        "VK_KHR_synchronization2",
+        // Drives correct DPB reference tracking across encode submissions.
+        "VK_KHR_video_maintenance1",
+        // H.264 encode was promoted EXT to KHR at ratification. LWJGL 3.3.2
+        // only exposes the EXT name; hasRequiredExtensions records which
+        // name the device advertises so createLogicalDevice enables it.
+    };
+
+    private static final String[] H264_ENCODE_EXTENSION_ALIASES = {
+        VK_KHR_VIDEO_ENCODE_H264_EXTENSION_NAME,
+        "VK_EXT_video_encode_h264", // pre-ratification name, kept for old drivers
     };
 
     public void initialize()
@@ -110,7 +131,10 @@ public class VulkanDevice implements AutoCloseable
                 .applicationVersion(VK_MAKE_VERSION(1, 0, 0))
                 .pEngineName(stack.UTF8("osrs-tracker"))
                 .engineVersion(VK_MAKE_VERSION(1, 0, 0))
-                .apiVersion(VK_API_VERSION_1_1);
+                // 1.3 core exposes VkCmdPipelineBarrier2 and synchronization2
+                // directly; required by the video encode pipeline-barrier usage.
+                // VK_API_VERSION_1_3 isn't a constant in LWJGL 3.3.2; use the macro.
+                .apiVersion(VK_MAKE_API_VERSION(0, 1, 3, 0));
 
             // Only enable validation in dev mode
             boolean enableValidation = hasValidation &&
@@ -120,7 +144,6 @@ public class VulkanDevice implements AutoCloseable
             if (enableValidation)
             {
                 ppEnabledLayers = stack.pointers(stack.UTF8("VK_LAYER_KHRONOS_validation"));
-                log.debug("Vulkan validation layers enabled");
             }
 
             PointerBuffer ppEnabledExtensions = null;
@@ -142,8 +165,6 @@ public class VulkanDevice implements AutoCloseable
                 throw new RuntimeException("vkCreateInstance failed: " + result);
             }
             instance = new VkInstance(pInstance.get(0), createInfo);
-
-            log.debug("Vulkan instance created");
         }
     }
 
@@ -166,6 +187,7 @@ public class VulkanDevice implements AutoCloseable
             VkPhysicalDevice bestDevice = null;
             int bestScore = -1;
             int bestQueueFamily = -1;
+            int bestGraphicsFamily = -1;
             String bestName = "unknown";
 
             for (int i = 0; i < deviceCount; i++)
@@ -187,44 +209,45 @@ public class VulkanDevice implements AutoCloseable
                     score = 100;
                 }
 
-                int encodeFamily = findVideoEncodeQueueFamily(candidate, stack);
-                if (encodeFamily < 0)
+                int encodeFamily = findQueueFamily(candidate, VK_QUEUE_VIDEO_ENCODE_BIT_KHR, stack);
+                int gfxFamily = findQueueFamily(candidate,
+                    VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT, stack);
+                if (encodeFamily < 0 || gfxFamily < 0)
                 {
-                    log.debug("  {} -- no video encode queue, skipping", name);
                     continue;
                 }
-
                 if (!hasRequiredExtensions(candidate, stack))
                 {
-                    log.debug("  {} -- missing required extensions, skipping", name);
                     continue;
                 }
-
-                log.debug("  {} -- score={}, encodeQueue={}", name, score, encodeFamily);
 
                 if (score > bestScore)
                 {
                     bestScore = score;
                     bestDevice = candidate;
                     bestQueueFamily = encodeFamily;
+                    bestGraphicsFamily = gfxFamily;
                     bestName = name;
                 }
             }
 
             if (bestDevice == null)
             {
-                throw new RuntimeException("No GPU with Vulkan Video Encode support found");
+                throw new RuntimeException("No GPU with Vulkan Video Encode + graphics support found");
             }
 
             physicalDevice = bestDevice;
             videoEncodeQueueFamily = bestQueueFamily;
+            graphicsQueueFamily = bestGraphicsFamily;
             deviceName = bestName;
-
-            log.debug("Selected GPU: {}", deviceName);
         }
     }
 
-    private int findVideoEncodeQueueFamily(VkPhysicalDevice device, MemoryStack stack)
+    /**
+     * Returns the index of the first queue family whose flags contain ALL bits in
+     * {@code requiredFlags}, or -1 if none.
+     */
+    private int findQueueFamily(VkPhysicalDevice device, int requiredFlags, MemoryStack stack)
     {
         IntBuffer pCount = stack.mallocInt(1);
         vkGetPhysicalDeviceQueueFamilyProperties(device, pCount, null);
@@ -235,13 +258,21 @@ public class VulkanDevice implements AutoCloseable
 
         for (int i = 0; i < count; i++)
         {
-            if ((families.get(i).queueFlags() & VK_QUEUE_VIDEO_ENCODE_BIT_KHR) != 0)
+            if ((families.get(i).queueFlags() & requiredFlags) == requiredFlags)
             {
                 return i;
             }
         }
         return -1;
     }
+
+    /**
+     * Name of the H.264 encode extension this device advertises (KHR or EXT),
+     * captured during selection so createLogicalDevice enables the correct string.
+     */
+    private String h264EncodeExtensionName;
+
+    String getH264EncodeExtensionName() { return h264EncodeExtensionName; }
 
     private boolean hasRequiredExtensions(VkPhysicalDevice device, MemoryStack stack)
     {
@@ -250,43 +281,80 @@ public class VulkanDevice implements AutoCloseable
         VkExtensionProperties.Buffer exts = VkExtensionProperties.calloc(pExtCount.get(0), stack);
         vkEnumerateDeviceExtensionProperties(device, (String) null, pExtCount, exts);
 
+        java.util.Set<String> available = new java.util.HashSet<>();
+        for (int i = 0; i < exts.capacity(); i++)
+        {
+            available.add(exts.get(i).extensionNameString());
+        }
+
         for (String required : REQUIRED_DEVICE_EXTENSIONS)
         {
-            boolean found = false;
-            for (int i = 0; i < exts.capacity(); i++)
-            {
-                if (required.equals(exts.get(i).extensionNameString()))
-                {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found)
+            if (!available.contains(required))
             {
                 return false;
             }
         }
-        return true;
+        for (String alias : H264_ENCODE_EXTENSION_ALIASES)
+        {
+            if (available.contains(alias))
+            {
+                h264EncodeExtensionName = alias;
+                return true;
+            }
+        }
+        return false;
     }
 
     private void createLogicalDevice()
     {
         try (MemoryStack stack = stackPush())
         {
-            VkDeviceQueueCreateInfo.Buffer queueCreateInfos = VkDeviceQueueCreateInfo.calloc(1, stack)
+            // Two queues: graphics (for upload) + video encode. If both landed in
+            // the same family (rare on AMD, possible on some integrated parts), we
+            // only need one VkDeviceQueueCreateInfo.
+            boolean sharedFamily = graphicsQueueFamily == videoEncodeQueueFamily;
+            VkDeviceQueueCreateInfo.Buffer queueCreateInfos =
+                VkDeviceQueueCreateInfo.calloc(sharedFamily ? 1 : 2, stack);
+            queueCreateInfos.get(0)
                 .sType(VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
                 .queueFamilyIndex(videoEncodeQueueFamily)
                 .pQueuePriorities(stack.floats(1.0f));
+            if (!sharedFamily)
+            {
+                queueCreateInfos.get(1)
+                    .sType(VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
+                    .queueFamilyIndex(graphicsQueueFamily)
+                    .pQueuePriorities(stack.floats(1.0f));
+            }
 
-            PointerBuffer ppExtensions = stack.mallocPointer(REQUIRED_DEVICE_EXTENSIONS.length);
+            PointerBuffer ppExtensions = stack.mallocPointer(REQUIRED_DEVICE_EXTENSIONS.length + 1);
             for (String ext : REQUIRED_DEVICE_EXTENSIONS)
             {
                 ppExtensions.put(stack.UTF8(ext));
             }
+            ppExtensions.put(stack.UTF8(h264EncodeExtensionName));
             ppExtensions.flip();
+
+            // Enable synchronization2 feature at device creation. Required by
+            // the VK13 vkCmdPipelineBarrier2 calls in the encode pipeline;
+            // enabling just the extension isn't enough, the feature bit matters.
+            VkPhysicalDeviceSynchronization2Features sync2Features =
+                VkPhysicalDeviceSynchronization2Features.calloc(stack)
+                    .sType$Default()
+                    .synchronization2(true);
+
+            // Enable videoMaintenance1: spec requires the feature bit be set to
+            // use the extension's session-create flags. Enabling just the extension
+            // gives the layout-transition fixes but not inline queries.
+            VkPhysicalDeviceVideoMaintenance1FeaturesKHR videoMaint1Features =
+                VkPhysicalDeviceVideoMaintenance1FeaturesKHR.calloc(stack)
+                    .sType(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR)
+                    .pNext(sync2Features.address())
+                    .videoMaintenance1(true);
 
             VkDeviceCreateInfo deviceCreateInfo = VkDeviceCreateInfo.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
+                .pNext(videoMaint1Features.address())
                 .pQueueCreateInfos(queueCreateInfos)
                 .ppEnabledExtensionNames(ppExtensions);
 
@@ -302,7 +370,9 @@ public class VulkanDevice implements AutoCloseable
             vkGetDeviceQueue(device, videoEncodeQueueFamily, 0, pQueue);
             videoEncodeQueue = new VkQueue(pQueue.get(0), device);
 
-            log.debug("Vulkan device created, encode queue acquired");
+            PointerBuffer pGfxQueue = stack.mallocPointer(1);
+            vkGetDeviceQueue(device, graphicsQueueFamily, 0, pGfxQueue);
+            graphicsQueue = new VkQueue(pGfxQueue.get(0), device);
         }
     }
 
@@ -311,6 +381,8 @@ public class VulkanDevice implements AutoCloseable
     public VkDevice getDevice() { return device; }
     public VkQueue getVideoEncodeQueue() { return videoEncodeQueue; }
     public int getVideoEncodeQueueFamily() { return videoEncodeQueueFamily; }
+    public VkQueue getGraphicsQueue() { return graphicsQueue; }
+    public int getGraphicsQueueFamily() { return graphicsQueueFamily; }
     public String getDeviceName() { return deviceName; }
 
     @Override
@@ -335,7 +407,5 @@ public class VulkanDevice implements AutoCloseable
         {
             vkDestroyInstance(instance, null);
         }
-
-        log.debug("Vulkan device closed");
     }
 }

--- a/src/main/java/com/osrstracker/video/encode/VulkanEncoder.java
+++ b/src/main/java/com/osrstracker/video/encode/VulkanEncoder.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.*;
-import org.lwjgl.vulkan.video.*;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -38,26 +37,15 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.lwjgl.system.MemoryStack.stackPush;
-import static org.lwjgl.system.MemoryUtil.*;
-import static org.lwjgl.vulkan.EXTVideoEncodeH264.*;
-import static org.lwjgl.vulkan.KHRVideoEncodeQueue.*;
-import static org.lwjgl.vulkan.KHRVideoQueue.*;
 import static org.lwjgl.vulkan.VK10.*;
-import static org.lwjgl.vulkan.VK13.*;
-import static org.lwjgl.vulkan.video.STDVulkanVideoCodecH264.*;
 
 /**
- * Vulkan H.264 video encoder using hardware video encode extensions.
+ * H.264 video encoder backed by {@code VK_KHR_video_encode_h264}.
  *
- * Architecture: Uses MjpegEncoder's JPEG circular buffer for continuous recording
- * (zero GPU overhead during normal gameplay). When a clip is requested, burst-encodes
- * the JPEG frames to H.264 on the GPU hardware encoder. The GPU can encode 1000+ FPS,
- * so 300 frames takes ~0.3 seconds.
- *
- * This means:
- * - During gameplay: same as MJPEG (JPEG buffer rolling, ~15-30MB memory)
- * - On clip request: GPU burst-encodes JPEG -> H.264, output ~5-7MB instead of 130MB
- * - Zero GPU encode overhead during normal play
+ * Frames captured on the game thread are buffered as JPEGs in an
+ * {@link MjpegEncoder} ring; the GPU encode queue is exercised only during
+ * {@link #finalizeClip}, which burst-decodes the ring and re-encodes to an
+ * H.264 Annex B bitstream.
  */
 @Slf4j
 public class VulkanEncoder implements VideoEncoder, AutoCloseable
@@ -65,34 +53,34 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
     private final VulkanDevice vulkanDevice;
     private final VulkanCapabilities caps;
 
-    // Delegate to MjpegEncoder for continuous JPEG buffer recording
     private final MjpegEncoder jpegBuffer = new MjpegEncoder();
 
-    // Vulkan resources (created lazily on first finalizeClip)
+    // Destroyed once at shutdown.
+    private final Disposables persistent = new Disposables();
+
     private H264SessionConfig sessionConfig;
+    // Per-clip GPU resources; rebuilt on dimension change.
+    private EncodeResources resources;
+    private FrameEncoder frameEncoder;
+
     private long commandPool = VK_NULL_HANDLE;
-    private VkCommandBuffer commandBuffer;
-    private long encodeFence = VK_NULL_HANDLE;
+    private final VkCommandBuffer[] commandBuffers = new VkCommandBuffer[EncodeResources.RING_DEPTH];
+    private final long[] encodeFences = new long[EncodeResources.RING_DEPTH];
+    // Video-encode queue has no TRANSFER bit on AMD/NVIDIA/Intel, so the NV12
+    // upload runs on graphics and transfers ownership via QFOT.
+    private long gfxCommandPool = VK_NULL_HANDLE;
+    private final VkCommandBuffer[] gfxCommandBuffers = new VkCommandBuffer[EncodeResources.RING_DEPTH];
+    private final long[] uploadSemaphores = new long[EncodeResources.RING_DEPTH];
 
-    // Encode images and buffers (sized to last encode resolution)
-    private long encodeInputImage = VK_NULL_HANDLE;
-    private long encodeInputImageView = VK_NULL_HANDLE;
-    private long encodeInputMemory = VK_NULL_HANDLE;
-    private long dpbImage = VK_NULL_HANDLE;
-    private final long[] dpbImageViews = new long[2];
-    private long dpbMemory = VK_NULL_HANDLE;
-    private long bitstreamBuffer = VK_NULL_HANDLE;
-    private long bitstreamMemory = VK_NULL_HANDLE;
-    private long bitstreamMappedPtr = 0;
-    private long stagingBuffer = VK_NULL_HANDLE;
-    private long stagingMemory = VK_NULL_HANDLE;
-    private long stagingMappedPtr = 0;
-
-    private static final int BITSTREAM_BUFFER_SIZE = 4 * 1024 * 1024; // 4 MB per frame max
     private static final long FENCE_TIMEOUT_NS = 5_000_000_000L;
 
     private int encodedWidth = 0;
     private int encodedHeight = 0;
+    private int sourceWidth = 0;
+    private int sourceHeight = 0;
+    /** Source FPS from {@link #start(int, float)} or {@link #burstEncode(List, int)}.
+     *  Drives IDR period and rate control. {@code -1} if not set yet. */
+    private int sourceFps = -1;
     private boolean vulkanInitialized = false;
     private boolean closed = false;
 
@@ -105,9 +93,9 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
     @Override
     public void start(int fps, float quality)
     {
-        // Just start the JPEG buffer -- Vulkan resources are created lazily
+        if (fps <= 0) throw new IllegalArgumentException("fps must be positive, got " + fps);
+        this.sourceFps = fps;
         jpegBuffer.start(fps, quality);
-        log.debug("VulkanEncoder started at {} FPS (JPEG buffer active, GPU encode on clip)", fps);
     }
 
     @Override
@@ -121,45 +109,49 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
     @Override
     public void submitFrame(ByteBuffer rgbaPixels, int width, int height, long timestamp, boolean needsBlur)
     {
-        // Delegate to JPEG buffer -- zero GPU overhead during normal gameplay
         jpegBuffer.submitFrame(rgbaPixels, width, height, timestamp, needsBlur);
     }
 
     @Override
     public ClipData finalizeClip(long startTime, long endTime)
     {
-        // Step 1: Get JPEG frames from the circular buffer (handles blur)
-        ClipData mjpegClip = jpegBuffer.finalizeClip(startTime, endTime);
-        if (mjpegClip == null || mjpegClip.getFrames().isEmpty())
+        List<MjpegEncoder.TimestampedFrame> frames = jpegBuffer.snapshot(startTime, endTime);
+        if (frames.isEmpty())
         {
             return null;
         }
 
-        // Step 2: Burst-encode JPEGs to H.264 on the GPU
+        List<byte[]> jpegs = new ArrayList<>(frames.size());
+        long[] timestamps = new long[frames.size()];
+        for (int i = 0; i < frames.size(); i++)
+        {
+            jpegs.add(frames.get(i).jpeg);
+            timestamps[i] = frames.get(i).timestampMs;
+        }
+
         try
         {
-            byte[] h264Bitstream = burstEncode(mjpegClip.getFrames());
+            byte[] h264Bitstream = burstEncode(jpegs);
             if (h264Bitstream == null || h264Bitstream.length == 0)
             {
-                log.debug("Vulkan burst encode failed, falling back to MJPEG");
-                return mjpegClip;
+                log.warn("Vulkan burst encode returned empty, falling back to MJPEG");
+                return mjpegFallback(jpegs);
             }
-
-            log.debug("Burst encoded {} frames: {}MB MJPEG -> {}KB H.264",
-                mjpegClip.getFrames().size(),
-                mjpegClip.getTotalSize() / (1024 * 1024),
-                h264Bitstream.length / 1024);
-
-            return new ClipData(
-                Collections.singletonList(h264Bitstream),
-                "application/octet-stream",
-                h264Bitstream.length);
+            byte[] mp4 = LocalMp4Writer.toBytes(h264Bitstream, getDriverSpsPps(),
+                sourceWidth, sourceHeight, sourceFps, timestamps);
+            return new ClipData(Collections.singletonList(mp4), "video/mp4", mp4.length);
         }
         catch (Exception e)
         {
-            log.error("Vulkan burst encode failed, falling back to MJPEG", e);
-            return mjpegClip;
+            log.error("Vulkan burst encode threw, falling back to MJPEG", e);
+            return mjpegFallback(jpegs);
         }
+    }
+
+    private ClipData mjpegFallback(List<byte[]> jpegs)
+    {
+        long total = jpegs.stream().mapToLong(b -> b.length).sum();
+        return new ClipData(jpegs, "application/octet-stream", total);
     }
 
     @Override
@@ -174,37 +166,69 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
         return "vulkan-h264";
     }
 
-    // ---- Burst encode: JPEG frames -> H.264 bitstream ----
+    /**
+     * Returns the driver-emitted SPS+PPS NAL bodies from the current session,
+     * or {@code null} if no session exists yet. NAL bodies are returned
+     * without Annex B start codes; {@link AnnexBWriter#splitNalus} splits them.
+     */
+    byte[] getDriverSpsPps()
+    {
+        if (sessionConfig == null) return null;
+        return sessionConfig.fetchEncodedSpsPps(0, 0, true, true);
+    }
 
     /**
-     * Takes a list of JPEG byte arrays, decodes each to raw pixels,
-     * feeds them through the Vulkan H.264 encoder in sequence,
-     * and returns the complete H.264 Annex B bitstream.
+     * Burst-encode with an explicit source FPS, for callers that bypass
+     * {@link #start(int, float)} (e.g. the offline MJPEG-to-MP4 tool).
      */
-    private byte[] burstEncode(List<byte[]> jpegFrames)
+    byte[] burstEncode(List<byte[]> jpegFrames, int sourceFps)
     {
-        // Decode first frame to get dimensions
-        java.awt.image.BufferedImage firstFrame = decodeJpeg(jpegFrames.get(0));
-        if (firstFrame == null)
+        if (sourceFps <= 0) throw new IllegalArgumentException("sourceFps must be positive");
+        int prev = this.sourceFps;
+        this.sourceFps = sourceFps;
+        try
         {
-            return null;
+            return burstEncode(jpegFrames);
         }
+        finally
+        {
+            this.sourceFps = prev;
+        }
+    }
+
+    // Package-private so MjpegToMp4Tool can drive the encoder standalone.
+    byte[] burstEncode(List<byte[]> jpegFrames)
+    {
+        java.awt.image.BufferedImage firstFrame = decodeJpeg(jpegFrames.get(0));
+        if (firstFrame == null) return null;
 
         int width = firstFrame.getWidth();
         int height = firstFrame.getHeight();
+        sourceWidth = width;
+        sourceHeight = height;
 
-        // Initialize or reinitialize Vulkan resources if dimensions changed
-        if (!vulkanInitialized || width != encodedWidth || height != encodedHeight)
+        // NV12 + H.264 MB alignment require multiples of 16; SPS frame_cropping
+        // hides the padding at decode time.
+        int paddedWidth = (width + 15) & ~15;
+        int paddedHeight = (height + 15) & ~15;
+
+        if (!vulkanInitialized || paddedWidth != encodedWidth || paddedHeight != encodedHeight)
         {
             destroyEncodeResources();
-            initializeVulkan(width, height, jpegFrames.size());
-            encodedWidth = width;
-            encodedHeight = height;
+            initializeVulkan(paddedWidth, paddedHeight, jpegFrames.size());
+            encodedWidth = paddedWidth;
+            encodedHeight = paddedHeight;
         }
 
+        if (sourceFps <= 0)
+        {
+            throw new IllegalStateException(
+                "burstEncode called without a known source FPS; call start(fps, quality) first "
+                + "or use the burstEncode(frames, fps) overload.");
+        }
         ByteArrayOutputStream bitstreamOut = new ByteArrayOutputStream(jpegFrames.size() * 50000);
         int frameIndex = 0;
-        int fps = Math.max(jpegFrames.size() / 10, 20); // Estimate FPS from frame count
+        int fps = sourceFps;
 
         for (byte[] jpegBytes : jpegFrames)
         {
@@ -212,30 +236,33 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
                 ? firstFrame
                 : decodeJpeg(jpegBytes);
 
-            if (frame == null)
-            {
-                continue;
-            }
+            if (frame == null) continue;
 
             boolean isIdr = (frameIndex % fps) == 0;
-            byte[] encodedNalus = encodeOneFrame(frame, width, height, isIdr, frameIndex);
-
-            if (encodedNalus != null && encodedNalus.length > 0)
-            {
-                try
-                {
-                    bitstreamOut.write(encodedNalus);
-                }
-                catch (java.io.IOException e)
-                {
-                    log.error("Failed to write NALU data", e);
-                }
-            }
-
+            byte[] prev = frameEncoder.encodeFrame(frame, width, height, isIdr, frameIndex);
+            writeNalus(bitstreamOut, prev);
             frameIndex++;
         }
 
+        for (byte[] tail : frameEncoder.drainRemaining())
+        {
+            writeNalus(bitstreamOut, tail);
+        }
+
         return bitstreamOut.toByteArray();
+    }
+
+    private void writeNalus(ByteArrayOutputStream out, byte[] nalus)
+    {
+        if (nalus == null || nalus.length == 0) return;
+        try
+        {
+            out.write(nalus);
+        }
+        catch (java.io.IOException e)
+        {
+            log.error("Failed to write NALU data", e);
+        }
     }
 
     private java.awt.image.BufferedImage decodeJpeg(byte[] jpegBytes)
@@ -251,300 +278,6 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
         }
     }
 
-    /**
-     * Encodes a single frame to H.264 using the Vulkan hardware encoder.
-     * Returns the Annex B NALUs for this frame.
-     */
-    private byte[] encodeOneFrame(java.awt.image.BufferedImage frame, int width, int height,
-                                  boolean isIdr, int frameIndex)
-    {
-        VkDevice device = vulkanDevice.getDevice();
-
-        // Extract RGB pixels and upload to staging buffer
-        int[] rgbPixels = frame.getRGB(0, 0, width, height, null, 0, width);
-        ByteBuffer staging = memByteBuffer(stagingMappedPtr, width * height * 4);
-        staging.clear();
-        for (int pixel : rgbPixels)
-        {
-            staging.put((byte) ((pixel >> 16) & 0xFF)); // R
-            staging.put((byte) ((pixel >> 8) & 0xFF));  // G
-            staging.put((byte) (pixel & 0xFF));          // B
-            staging.put((byte) 0xFF);                    // A
-        }
-        staging.flip();
-
-        try (MemoryStack stack = stackPush())
-        {
-            vkWaitForFences(device, encodeFence, true, FENCE_TIMEOUT_NS);
-            vkResetFences(device, encodeFence);
-            vkResetCommandPool(device, commandPool, 0);
-
-            VkCommandBufferBeginInfo beginInfo = VkCommandBufferBeginInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO)
-                .flags(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-            vkBeginCommandBuffer(commandBuffer, beginInfo);
-
-            // Transition encode input: UNDEFINED -> TRANSFER_DST
-            imageBarrier2(stack, encodeInputImage,
-                VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                0, VK_ACCESS_TRANSFER_WRITE_BIT,
-                VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                0);
-
-            // Copy staging -> encode input
-            VkBufferImageCopy.Buffer copyRegion = VkBufferImageCopy.calloc(1, stack)
-                .bufferOffset(0)
-                .bufferRowLength(0)
-                .bufferImageHeight(0)
-                .imageSubresource(s -> s
-                    .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
-                    .mipLevel(0)
-                    .baseArrayLayer(0)
-                    .layerCount(1))
-                .imageOffset(o -> o.set(0, 0, 0))
-                .imageExtent(e -> e.set(width, height, 1));
-
-            vkCmdCopyBufferToImage(commandBuffer, stagingBuffer, encodeInputImage,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, copyRegion);
-
-            // Transition encode input: TRANSFER_DST -> VIDEO_ENCODE_SRC
-            imageBarrier2(stack, encodeInputImage,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR,
-                VK_ACCESS_TRANSFER_WRITE_BIT, 0,
-                VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
-                0,
-                VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR,
-                VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR);
-
-            int dpbSlot = frameIndex % 2;
-            int refSlot = (frameIndex + 1) % 2;
-
-            recordEncodeCommand(stack, isIdr, dpbSlot, refSlot, frameIndex);
-
-            // Barrier: bitstream -> host readable
-            bufferBarrier2(stack, bitstreamBuffer,
-                VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR, VK_ACCESS_HOST_READ_BIT,
-                VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR, VK_PIPELINE_STAGE_HOST_BIT);
-
-            vkEndCommandBuffer(commandBuffer);
-
-            // Submit and wait
-            VkSubmitInfo submitInfo = VkSubmitInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_SUBMIT_INFO)
-                .pCommandBuffers(stack.pointers(commandBuffer));
-
-            int result = vkQueueSubmit(vulkanDevice.getVideoEncodeQueue(), submitInfo, encodeFence);
-            if (result != VK_SUCCESS)
-            {
-                log.error("vkQueueSubmit failed: {}", result);
-                return null;
-            }
-
-            vkWaitForFences(device, encodeFence, true, FENCE_TIMEOUT_NS);
-
-            // Invalidate CPU cache for HOST_CACHED memory
-            VkMappedMemoryRange range = VkMappedMemoryRange.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE)
-                .memory(bitstreamMemory)
-                .offset(0)
-                .size(VK_WHOLE_SIZE);
-            vkInvalidateMappedMemoryRanges(device, range);
-
-            // Read back bitstream
-            ByteBuffer bitstream = memByteBuffer(bitstreamMappedPtr, BITSTREAM_BUFFER_SIZE);
-            int dataEnd = findBitstreamEnd(bitstream);
-            if (dataEnd <= 0)
-            {
-                return null;
-            }
-
-            byte[] naluData = new byte[dataEnd];
-            bitstream.rewind();
-            bitstream.get(naluData, 0, dataEnd);
-            return naluData;
-        }
-    }
-
-    private void recordEncodeCommand(MemoryStack stack, boolean isIdr, int dpbSlot, int refSlot,
-                                     int frameIndex)
-    {
-        // Transition DPB images on first frame
-        if (frameIndex == 0)
-        {
-            for (int i = 0; i < 2; i++)
-            {
-                imageBarrier2(stack, dpbImage,
-                    VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_VIDEO_ENCODE_DPB_KHR,
-                    0, 0,
-                    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0,
-                    i,
-                    VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR | VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR,
-                    VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR);
-            }
-        }
-
-        // Source picture
-        VkVideoPictureResourceInfoKHR srcPicture = VkVideoPictureResourceInfoKHR.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
-            .codedOffset(o -> o.set(0, 0))
-            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
-            .baseArrayLayer(0)
-            .imageViewBinding(encodeInputImageView);
-
-        // Setup slot (reconstructed picture)
-        VkVideoEncodeH264DpbSlotInfoEXT h264DpbSlotInfo = VkVideoEncodeH264DpbSlotInfoEXT.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT);
-
-        VkVideoPictureResourceInfoKHR setupPicResource = VkVideoPictureResourceInfoKHR.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
-            .codedOffset(o -> o.set(0, 0))
-            .codedExtent(e -> e.set(encodedWidth, encodedHeight))
-            .baseArrayLayer(dpbSlot)
-            .imageViewBinding(dpbImageViews[dpbSlot]);
-
-        VkVideoReferenceSlotInfoKHR setupSlot = VkVideoReferenceSlotInfoKHR.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
-            .pNext(h264DpbSlotInfo.address())
-            .slotIndex(dpbSlot)
-            .pPictureResource(setupPicResource);
-
-        // Reference slots for P-frames
-        VkVideoReferenceSlotInfoKHR.Buffer referenceSlots = null;
-        if (!isIdr && frameIndex > 0)
-        {
-            VkVideoEncodeH264DpbSlotInfoEXT refH264Info = VkVideoEncodeH264DpbSlotInfoEXT.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT);
-
-            VkVideoPictureResourceInfoKHR refPicResource = VkVideoPictureResourceInfoKHR.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
-                .codedOffset(o -> o.set(0, 0))
-                .codedExtent(e -> e.set(encodedWidth, encodedHeight))
-                .baseArrayLayer(refSlot)
-                .imageViewBinding(dpbImageViews[refSlot]);
-
-            referenceSlots = VkVideoReferenceSlotInfoKHR.calloc(1, stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
-                .pNext(refH264Info.address())
-                .slotIndex(refSlot)
-                .pPictureResource(refPicResource);
-        }
-
-        // H.264 picture info
-        StdVideoEncodeH264PictureInfoFlags picFlags = StdVideoEncodeH264PictureInfoFlags.calloc(stack)
-            .idr_flag(isIdr)
-            .is_reference_flag(true);
-
-        StdVideoEncodeH264PictureInfo picInfo = StdVideoEncodeH264PictureInfo.calloc(stack)
-            .flags(picFlags)
-            .seq_parameter_set_id((byte) 0)
-            .pic_parameter_set_id((byte) 0)
-            .pictureType(isIdr ? STD_VIDEO_H264_PICTURE_TYPE_IDR : STD_VIDEO_H264_PICTURE_TYPE_P)
-            .frame_num(frameIndex % 16);
-
-        // Reference lists
-        StdVideoEncodeH264ReferenceListsInfo refLists = StdVideoEncodeH264ReferenceListsInfo.calloc(stack);
-        if (!isIdr && frameIndex > 0)
-        {
-            ByteBuffer l0Entries = stack.bytes((byte) refSlot);
-            StdVideoEncodeH264ReferenceListsInfo.nrefPicList0EntryCount(refLists.address(), (byte) 1);
-            refLists.pRefPicList0Entries(l0Entries);
-        }
-
-        // Slice info
-        StdVideoEncodeH264SliceHeaderFlags sliceFlags = StdVideoEncodeH264SliceHeaderFlags.calloc(stack);
-        StdVideoEncodeH264SliceHeader sliceHeader = StdVideoEncodeH264SliceHeader.calloc(stack)
-            .flags(sliceFlags)
-            .slice_type(isIdr ? STD_VIDEO_H264_SLICE_TYPE_I : STD_VIDEO_H264_SLICE_TYPE_P);
-
-        VkVideoEncodeH264NaluSliceInfoEXT.Buffer naluSliceInfo =
-            VkVideoEncodeH264NaluSliceInfoEXT.calloc(1, stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_EXT)
-                .mbCount(((encodedWidth + 15) / 16) * ((encodedHeight + 15) / 16))
-                .pStdReferenceFinalLists(refLists)
-                .pStdSliceHeader(sliceHeader);
-
-        VkVideoEncodeH264VclFrameInfoEXT h264FrameInfo = VkVideoEncodeH264VclFrameInfoEXT.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT)
-            .pStdReferenceFinalLists(refLists)
-            .pNaluSliceEntries(naluSliceInfo)
-            .pStdPictureInfo(picInfo);
-
-        // Begin video coding
-        VkVideoBeginCodingInfoKHR beginCoding = VkVideoBeginCodingInfoKHR.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR)
-            .videoSession(sessionConfig.getVideoSession())
-            .videoSessionParameters(sessionConfig.getSessionParameters());
-
-        VkVideoReferenceSlotInfoKHR.Buffer beginSlots = VkVideoReferenceSlotInfoKHR.calloc(2, stack);
-        for (int i = 0; i < 2; i++)
-        {
-            final int layer = i;
-            VkVideoPictureResourceInfoKHR slotPic = VkVideoPictureResourceInfoKHR.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR)
-                .codedOffset(o -> o.set(0, 0))
-                .codedExtent(e -> e.set(encodedWidth, encodedHeight))
-                .baseArrayLayer(layer)
-                .imageViewBinding(dpbImageViews[layer]);
-
-            beginSlots.get(i)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR)
-                .slotIndex(i)
-                .pPictureResource(slotPic);
-        }
-        beginCoding.pReferenceSlots(beginSlots);
-
-        vkCmdBeginVideoCodingKHR(commandBuffer, beginCoding);
-
-        // Reset session on first frame of each burst
-        if (frameIndex == 0)
-        {
-            VkVideoCodingControlInfoKHR controlInfo = VkVideoCodingControlInfoKHR.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR)
-                .flags(VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR);
-            vkCmdControlVideoCodingKHR(commandBuffer, controlInfo);
-        }
-
-        // Encode
-        VkVideoEncodeInfoKHR encodeInfo = VkVideoEncodeInfoKHR.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR)
-            .pNext(h264FrameInfo.address())
-            .dstBuffer(bitstreamBuffer)
-            .dstBufferOffset(0)
-            .dstBufferRange(BITSTREAM_BUFFER_SIZE)
-            .srcPictureResource(srcPicture)
-            .pSetupReferenceSlot(setupSlot)
-            .pReferenceSlots(referenceSlots);
-
-        vkCmdEncodeVideoKHR(commandBuffer, encodeInfo);
-
-        // End video coding
-        VkVideoEndCodingInfoKHR endCoding = VkVideoEndCodingInfoKHR.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR);
-        vkCmdEndVideoCodingKHR(commandBuffer, endCoding);
-    }
-
-    private int findBitstreamEnd(ByteBuffer buffer)
-    {
-        buffer.rewind();
-        int lastNonZero = 0;
-
-        for (int i = 0; i < buffer.remaining(); i++)
-        {
-            if (buffer.get(i) != 0)
-            {
-                lastNonZero = i + 1;
-            }
-            if (i - lastNonZero > 64)
-            {
-                break;
-            }
-        }
-
-        return lastNonZero;
-    }
-
-    // ---- Vulkan resource lifecycle (lazy init) ----
-
     private void initializeVulkan(int width, int height, int frameCount)
     {
         if (!vulkanInitialized)
@@ -554,513 +287,153 @@ public class VulkanEncoder implements VideoEncoder, AutoCloseable
             vulkanInitialized = true;
         }
 
-        int fps = Math.max(frameCount / 10, 20);
+        int fps = sourceFps > 0 ? sourceFps : 30;
         sessionConfig = new H264SessionConfig(vulkanDevice, caps, width, height, fps);
         sessionConfig.initialize();
 
-        createEncodeInputImage(width, height);
-        createDpbImages(width, height);
-        createBitstreamBuffer();
-        createStagingBuffer(width, height);
+        resources = new EncodeResources(vulkanDevice, caps, width, height);
         allocateCommandBuffer();
+
+        frameEncoder = new FrameEncoder(
+            vulkanDevice, caps, sessionConfig, resources,
+            commandBuffers, gfxCommandBuffers,
+            encodeFences, uploadSemaphores,
+            width, height, fps);
     }
 
     private void createCommandPool()
     {
+        VkDevice device = vulkanDevice.getDevice();
         try (MemoryStack stack = stackPush())
         {
-            VkCommandPoolCreateInfo poolInfo = VkCommandPoolCreateInfo.calloc(stack)
+            // Encode-queue pool. RESET_COMMAND_BUFFER_BIT so ring slots can
+            // be reset individually; pool-wide reset would clobber pending work.
+            VkCommandPoolCreateInfo encPool = VkCommandPoolCreateInfo.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO)
-                .flags(VK_COMMAND_POOL_CREATE_TRANSIENT_BIT)
+                .flags(VK_COMMAND_POOL_CREATE_TRANSIENT_BIT
+                    | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
                 .queueFamilyIndex(vulkanDevice.getVideoEncodeQueueFamily());
-
             LongBuffer pPool = stack.mallocLong(1);
-            int result = vkCreateCommandPool(vulkanDevice.getDevice(), poolInfo, null, pPool);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkCreateCommandPool failed: " + result);
-            }
+            int r = vkCreateCommandPool(device, encPool, null, pPool);
+            if (r != VK_SUCCESS) throw new RuntimeException("encode vkCreateCommandPool failed: " + r);
             commandPool = pPool.get(0);
+            persistent.add(() -> vkDestroyCommandPool(device, commandPool, null));
+
+            // Graphics-queue pool (for the NV12 upload).
+            VkCommandPoolCreateInfo gfxPool = VkCommandPoolCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO)
+                .flags(VK_COMMAND_POOL_CREATE_TRANSIENT_BIT
+                    | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
+                .queueFamilyIndex(vulkanDevice.getGraphicsQueueFamily());
+            r = vkCreateCommandPool(device, gfxPool, null, pPool);
+            if (r != VK_SUCCESS) throw new RuntimeException("graphics vkCreateCommandPool failed: " + r);
+            gfxCommandPool = pPool.get(0);
+            persistent.add(() -> vkDestroyCommandPool(device, gfxCommandPool, null));
         }
     }
 
     private void allocateCommandBuffer()
     {
+        VkDevice device = vulkanDevice.getDevice();
         try (MemoryStack stack = stackPush())
         {
-            VkCommandBufferAllocateInfo allocInfo = VkCommandBufferAllocateInfo.calloc(stack)
+            VkCommandBufferAllocateInfo encAlloc = VkCommandBufferAllocateInfo.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO)
                 .commandPool(commandPool)
                 .level(VK_COMMAND_BUFFER_LEVEL_PRIMARY)
-                .commandBufferCount(1);
-
-            PointerBuffer pCmdBuf = stack.mallocPointer(1);
-            int result = vkAllocateCommandBuffers(vulkanDevice.getDevice(), allocInfo, pCmdBuf);
-            if (result != VK_SUCCESS)
+                .commandBufferCount(EncodeResources.RING_DEPTH);
+            PointerBuffer pCmdBuf = stack.mallocPointer(EncodeResources.RING_DEPTH);
+            int r = vkAllocateCommandBuffers(device, encAlloc, pCmdBuf);
+            if (r != VK_SUCCESS) throw new RuntimeException("encode vkAllocateCommandBuffers failed: " + r);
+            for (int i = 0; i < EncodeResources.RING_DEPTH; i++)
             {
-                throw new RuntimeException("vkAllocateCommandBuffers failed: " + result);
+                commandBuffers[i] = new VkCommandBuffer(pCmdBuf.get(i), device);
             }
-            commandBuffer = new VkCommandBuffer(pCmdBuf.get(0), vulkanDevice.getDevice());
+
+            VkCommandBufferAllocateInfo gfxAlloc = VkCommandBufferAllocateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO)
+                .commandPool(gfxCommandPool)
+                .level(VK_COMMAND_BUFFER_LEVEL_PRIMARY)
+                .commandBufferCount(EncodeResources.RING_DEPTH);
+            pCmdBuf.clear();
+            r = vkAllocateCommandBuffers(device, gfxAlloc, pCmdBuf);
+            if (r != VK_SUCCESS) throw new RuntimeException("graphics vkAllocateCommandBuffers failed: " + r);
+            for (int i = 0; i < EncodeResources.RING_DEPTH; i++)
+            {
+                gfxCommandBuffers[i] = new VkCommandBuffer(pCmdBuf.get(i), device);
+            }
         }
     }
 
     private void createSyncPrimitives()
     {
+        VkDevice device = vulkanDevice.getDevice();
         try (MemoryStack stack = stackPush())
         {
             VkFenceCreateInfo fenceInfo = VkFenceCreateInfo.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_FENCE_CREATE_INFO)
                 .flags(VK_FENCE_CREATE_SIGNALED_BIT);
-
-            LongBuffer pFence = stack.mallocLong(1);
-            int result = vkCreateFence(vulkanDevice.getDevice(), fenceInfo, null, pFence);
-            if (result != VK_SUCCESS)
+            VkSemaphoreCreateInfo semInfo = VkSemaphoreCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO);
+            LongBuffer p = stack.mallocLong(1);
+            for (int i = 0; i < EncodeResources.RING_DEPTH; i++)
             {
-                throw new RuntimeException("vkCreateFence failed: " + result);
-            }
-            encodeFence = pFence.get(0);
-        }
-    }
+                int r = vkCreateFence(device, fenceInfo, null, p);
+                if (r != VK_SUCCESS) throw new RuntimeException("vkCreateFence slot " + i + " failed: " + r);
+                encodeFences[i] = p.get(0);
+                final int slot = i;
+                persistent.add(() -> vkDestroyFence(device, encodeFences[slot], null));
 
-    private void createEncodeInputImage(int width, int height)
-    {
-        VkDevice device = vulkanDevice.getDevice();
-
-        try (MemoryStack stack = stackPush())
-        {
-            VkVideoProfileListInfoKHR profileList = VkVideoProfileListInfoKHR.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR)
-                .pProfiles(VkVideoProfileInfoKHR.calloc(1, stack).put(0, caps.buildVideoProfile(stack)));
-
-            VkImageCreateInfo imageInfo = VkImageCreateInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
-                .pNext(profileList.address())
-                .imageType(VK_IMAGE_TYPE_2D)
-                .format(caps.getPictureFormat())
-                .extent(e -> e.set(width, height, 1))
-                .mipLevels(1)
-                .arrayLayers(1)
-                .samples(VK_SAMPLE_COUNT_1_BIT)
-                .tiling(VK_IMAGE_TILING_OPTIMAL)
-                .usage(VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR | VK_IMAGE_USAGE_TRANSFER_DST_BIT)
-                .sharingMode(VK_SHARING_MODE_EXCLUSIVE)
-                .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
-
-            LongBuffer pImage = stack.mallocLong(1);
-            int result = vkCreateImage(device, imageInfo, null, pImage);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkCreateImage (encode input) failed: " + result);
-            }
-            encodeInputImage = pImage.get(0);
-
-            encodeInputMemory = allocateAndBindImageMemory(device, encodeInputImage,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, stack);
-
-            VkImageViewCreateInfo viewInfo = VkImageViewCreateInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
-                .image(encodeInputImage)
-                .viewType(VK_IMAGE_VIEW_TYPE_2D)
-                .format(caps.getPictureFormat())
-                .subresourceRange(r -> r
-                    .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
-                    .baseMipLevel(0)
-                    .levelCount(1)
-                    .baseArrayLayer(0)
-                    .layerCount(1));
-
-            LongBuffer pView = stack.mallocLong(1);
-            result = vkCreateImageView(device, viewInfo, null, pView);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkCreateImageView (encode input) failed: " + result);
-            }
-            encodeInputImageView = pView.get(0);
-        }
-    }
-
-    private void createDpbImages(int width, int height)
-    {
-        VkDevice device = vulkanDevice.getDevice();
-
-        try (MemoryStack stack = stackPush())
-        {
-            VkVideoProfileListInfoKHR profileList = VkVideoProfileListInfoKHR.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR)
-                .pProfiles(VkVideoProfileInfoKHR.calloc(1, stack).put(0, caps.buildVideoProfile(stack)));
-
-            VkImageCreateInfo imageInfo = VkImageCreateInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
-                .pNext(profileList.address())
-                .imageType(VK_IMAGE_TYPE_2D)
-                .format(caps.getPictureFormat())
-                .extent(e -> e.set(width, height, 1))
-                .mipLevels(1)
-                .arrayLayers(2)
-                .samples(VK_SAMPLE_COUNT_1_BIT)
-                .tiling(VK_IMAGE_TILING_OPTIMAL)
-                .usage(VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR)
-                .sharingMode(VK_SHARING_MODE_EXCLUSIVE)
-                .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
-
-            LongBuffer pImage = stack.mallocLong(1);
-            int result = vkCreateImage(device, imageInfo, null, pImage);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkCreateImage (DPB) failed: " + result);
-            }
-            dpbImage = pImage.get(0);
-
-            dpbMemory = allocateAndBindImageMemory(device, dpbImage,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, stack);
-
-            for (int i = 0; i < 2; i++)
-            {
-                final int layer = i;
-                VkImageViewCreateInfo viewInfo = VkImageViewCreateInfo.calloc(stack)
-                    .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
-                    .image(dpbImage)
-                    .viewType(VK_IMAGE_VIEW_TYPE_2D)
-                    .format(caps.getPictureFormat())
-                    .subresourceRange(r -> r
-                        .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
-                        .baseMipLevel(0)
-                        .levelCount(1)
-                        .baseArrayLayer(layer)
-                        .layerCount(1));
-
-                LongBuffer pView = stack.mallocLong(1);
-                result = vkCreateImageView(device, viewInfo, null, pView);
-                if (result != VK_SUCCESS)
-                {
-                    throw new RuntimeException("vkCreateImageView (DPB " + i + ") failed: " + result);
-                }
-                dpbImageViews[i] = pView.get(0);
+                // Binary semaphore signalled by the graphics submit (upload done),
+                // waited by the encode submit (QFOT acquire + encode).
+                r = vkCreateSemaphore(device, semInfo, null, p);
+                if (r != VK_SUCCESS) throw new RuntimeException("vkCreateSemaphore slot " + i + " failed: " + r);
+                uploadSemaphores[i] = p.get(0);
+                persistent.add(() -> vkDestroySemaphore(device, uploadSemaphores[slot], null));
             }
         }
     }
 
-    private void createBitstreamBuffer()
-    {
-        VkDevice device = vulkanDevice.getDevice();
-
-        try (MemoryStack stack = stackPush())
-        {
-            VkVideoProfileListInfoKHR profileList = VkVideoProfileListInfoKHR.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR)
-                .pProfiles(VkVideoProfileInfoKHR.calloc(1, stack).put(0, caps.buildVideoProfile(stack)));
-
-            VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO)
-                .pNext(profileList.address())
-                .size(BITSTREAM_BUFFER_SIZE)
-                .usage(VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR)
-                .sharingMode(VK_SHARING_MODE_EXCLUSIVE);
-
-            LongBuffer pBuffer = stack.mallocLong(1);
-            int result = vkCreateBuffer(device, bufferInfo, null, pBuffer);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkCreateBuffer (bitstream) failed: " + result);
-            }
-            bitstreamBuffer = pBuffer.get(0);
-
-            bitstreamMemory = allocateAndBindBufferMemory(device, bitstreamBuffer,
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, stack);
-
-            PointerBuffer pData = stack.mallocPointer(1);
-            result = vkMapMemory(device, bitstreamMemory, 0, BITSTREAM_BUFFER_SIZE, 0, pData);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkMapMemory (bitstream) failed: " + result);
-            }
-            bitstreamMappedPtr = pData.get(0);
-        }
-    }
-
-    private void createStagingBuffer(int width, int height)
-    {
-        VkDevice device = vulkanDevice.getDevice();
-        long bufferSize = (long) width * height * 4;
-
-        try (MemoryStack stack = stackPush())
-        {
-            VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.calloc(stack)
-                .sType(VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO)
-                .size(bufferSize)
-                .usage(VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
-                .sharingMode(VK_SHARING_MODE_EXCLUSIVE);
-
-            LongBuffer pBuffer = stack.mallocLong(1);
-            int result = vkCreateBuffer(device, bufferInfo, null, pBuffer);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkCreateBuffer (staging) failed: " + result);
-            }
-            stagingBuffer = pBuffer.get(0);
-
-            stagingMemory = allocateAndBindBufferMemory(device, stagingBuffer,
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stack);
-
-            PointerBuffer pData = stack.mallocPointer(1);
-            result = vkMapMemory(device, stagingMemory, 0, bufferSize, 0, pData);
-            if (result != VK_SUCCESS)
-            {
-                throw new RuntimeException("vkMapMemory (staging) failed: " + result);
-            }
-            stagingMappedPtr = pData.get(0);
-        }
-    }
-
-    // ---- Memory helpers ----
-
-    private long allocateAndBindImageMemory(VkDevice device, long image, int properties, MemoryStack stack)
-    {
-        VkMemoryRequirements memReqs = VkMemoryRequirements.calloc(stack);
-        vkGetImageMemoryRequirements(device, image, memReqs);
-
-        VkMemoryAllocateInfo allocInfo = VkMemoryAllocateInfo.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
-            .allocationSize(memReqs.size())
-            .memoryTypeIndex(findMemoryType(memReqs.memoryTypeBits(), properties, stack));
-
-        LongBuffer pMemory = stack.mallocLong(1);
-        int result = vkAllocateMemory(device, allocInfo, null, pMemory);
-        if (result != VK_SUCCESS)
-        {
-            throw new RuntimeException("vkAllocateMemory failed: " + result);
-        }
-        long memory = pMemory.get(0);
-        vkBindImageMemory(device, image, memory, 0);
-        return memory;
-    }
-
-    private long allocateAndBindBufferMemory(VkDevice device, long buffer, int properties, MemoryStack stack)
-    {
-        VkMemoryRequirements memReqs = VkMemoryRequirements.calloc(stack);
-        vkGetBufferMemoryRequirements(device, buffer, memReqs);
-
-        int memTypeIdx;
-        try
-        {
-            memTypeIdx = findMemoryType(memReqs.memoryTypeBits(), properties, stack);
-        }
-        catch (RuntimeException e)
-        {
-            memTypeIdx = findMemoryType(memReqs.memoryTypeBits(),
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, stack);
-        }
-
-        VkMemoryAllocateInfo allocInfo = VkMemoryAllocateInfo.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
-            .allocationSize(memReqs.size())
-            .memoryTypeIndex(memTypeIdx);
-
-        LongBuffer pMemory = stack.mallocLong(1);
-        int result = vkAllocateMemory(device, allocInfo, null, pMemory);
-        if (result != VK_SUCCESS)
-        {
-            throw new RuntimeException("vkAllocateMemory failed: " + result);
-        }
-        long memory = pMemory.get(0);
-        vkBindBufferMemory(device, buffer, memory, 0);
-        return memory;
-    }
-
-    private int findMemoryType(int typeFilter, int properties, MemoryStack stack)
-    {
-        VkPhysicalDeviceMemoryProperties memProps = VkPhysicalDeviceMemoryProperties.calloc(stack);
-        vkGetPhysicalDeviceMemoryProperties(vulkanDevice.getPhysicalDevice(), memProps);
-
-        for (int i = 0; i < memProps.memoryTypeCount(); i++)
-        {
-            if ((typeFilter & (1 << i)) != 0 &&
-                (memProps.memoryTypes(i).propertyFlags() & properties) == properties)
-            {
-                return i;
-            }
-        }
-
-        for (int i = 0; i < memProps.memoryTypeCount(); i++)
-        {
-            if ((typeFilter & (1 << i)) != 0)
-            {
-                return i;
-            }
-        }
-
-        throw new RuntimeException("Failed to find suitable memory type");
-    }
-
-    // ---- Barrier helpers (Synchronization2 / VK 1.3) ----
-
-    private void imageBarrier2(MemoryStack stack, long image,
-                               int oldLayout, int newLayout,
-                               int srcAccess, int dstAccess,
-                               int srcStage, int dstStage,
-                               int arrayLayer)
-    {
-        imageBarrier2(stack, image, oldLayout, newLayout,
-            srcAccess, dstAccess, srcStage, dstStage, arrayLayer, 0, 0);
-    }
-
-    private void imageBarrier2(MemoryStack stack, long image,
-                               int oldLayout, int newLayout,
-                               int srcAccess, int dstAccess,
-                               int srcStage, int dstStage,
-                               int arrayLayer,
-                               long dstAccess64, long dstStage64)
-    {
-        long finalDstAccess = dstAccess64 != 0 ? dstAccess64 : dstAccess;
-        long finalDstStage = dstStage64 != 0 ? dstStage64 : (dstStage != 0 ? dstStage : VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
-        long finalSrcStage = srcStage != 0 ? srcStage : VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-
-        VkImageMemoryBarrier2.Buffer barrier = VkImageMemoryBarrier2.calloc(1, stack)
-            .sType(VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2)
-            .srcStageMask(finalSrcStage)
-            .srcAccessMask(srcAccess)
-            .dstStageMask(finalDstStage)
-            .dstAccessMask(finalDstAccess)
-            .oldLayout(oldLayout)
-            .newLayout(newLayout)
-            .srcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-            .dstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-            .image(image)
-            .subresourceRange(r -> r
-                .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
-                .baseMipLevel(0)
-                .levelCount(1)
-                .baseArrayLayer(arrayLayer)
-                .layerCount(1));
-
-        VkDependencyInfo depInfo = VkDependencyInfo.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_DEPENDENCY_INFO)
-            .pImageMemoryBarriers(barrier);
-
-        vkCmdPipelineBarrier2(commandBuffer, depInfo);
-    }
-
-    private void bufferBarrier2(MemoryStack stack, long buffer,
-                                long srcAccess, long dstAccess,
-                                long srcStage, long dstStage)
-    {
-        VkBufferMemoryBarrier2.Buffer barrier = VkBufferMemoryBarrier2.calloc(1, stack)
-            .sType(VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2)
-            .srcStageMask(srcStage)
-            .srcAccessMask(srcAccess)
-            .dstStageMask(dstStage)
-            .dstAccessMask(dstAccess)
-            .buffer(buffer)
-            .offset(0)
-            .size(BITSTREAM_BUFFER_SIZE);
-
-        VkDependencyInfo depInfo = VkDependencyInfo.calloc(stack)
-            .sType(VK_STRUCTURE_TYPE_DEPENDENCY_INFO)
-            .pBufferMemoryBarriers(barrier);
-
-        vkCmdPipelineBarrier2(commandBuffer, depInfo);
-    }
 
     // ---- Cleanup ----
 
     private void destroyEncodeResources()
     {
+        // Drain any in-flight ring slots before tearing down the resources
+        // they reference; validation layers fire on destroy-while-pending.
         VkDevice device = vulkanDevice.getDevice();
-
-        if (encodeFence != VK_NULL_HANDLE)
+        for (long fence : encodeFences)
         {
-            vkWaitForFences(device, encodeFence, true, FENCE_TIMEOUT_NS);
+            if (fence != VK_NULL_HANDLE)
+            {
+                vkWaitForFences(device, fence, true, FENCE_TIMEOUT_NS);
+            }
         }
 
+        frameEncoder = null;
+        if (resources != null)
+        {
+            resources.close();
+            resources = null;
+        }
         if (sessionConfig != null)
         {
             sessionConfig.close();
             sessionConfig = null;
-        }
-
-        if (encodeInputImageView != VK_NULL_HANDLE)
-        {
-            vkDestroyImageView(device, encodeInputImageView, null);
-            encodeInputImageView = VK_NULL_HANDLE;
-        }
-        if (encodeInputImage != VK_NULL_HANDLE)
-        {
-            vkDestroyImage(device, encodeInputImage, null);
-            encodeInputImage = VK_NULL_HANDLE;
-        }
-        if (encodeInputMemory != VK_NULL_HANDLE)
-        {
-            vkFreeMemory(device, encodeInputMemory, null);
-            encodeInputMemory = VK_NULL_HANDLE;
-        }
-
-        for (int i = 0; i < 2; i++)
-        {
-            if (dpbImageViews[i] != VK_NULL_HANDLE)
-            {
-                vkDestroyImageView(device, dpbImageViews[i], null);
-                dpbImageViews[i] = VK_NULL_HANDLE;
-            }
-        }
-        if (dpbImage != VK_NULL_HANDLE)
-        {
-            vkDestroyImage(device, dpbImage, null);
-            dpbImage = VK_NULL_HANDLE;
-        }
-        if (dpbMemory != VK_NULL_HANDLE)
-        {
-            vkFreeMemory(device, dpbMemory, null);
-            dpbMemory = VK_NULL_HANDLE;
-        }
-
-        if (bitstreamMappedPtr != 0)
-        {
-            vkUnmapMemory(device, bitstreamMemory);
-            bitstreamMappedPtr = 0;
-        }
-        if (bitstreamBuffer != VK_NULL_HANDLE)
-        {
-            vkDestroyBuffer(device, bitstreamBuffer, null);
-            bitstreamBuffer = VK_NULL_HANDLE;
-        }
-        if (bitstreamMemory != VK_NULL_HANDLE)
-        {
-            vkFreeMemory(device, bitstreamMemory, null);
-            bitstreamMemory = VK_NULL_HANDLE;
-        }
-
-        if (stagingMappedPtr != 0)
-        {
-            vkUnmapMemory(device, stagingMemory);
-            stagingMappedPtr = 0;
-        }
-        if (stagingBuffer != VK_NULL_HANDLE)
-        {
-            vkDestroyBuffer(device, stagingBuffer, null);
-            stagingBuffer = VK_NULL_HANDLE;
-        }
-        if (stagingMemory != VK_NULL_HANDLE)
-        {
-            vkFreeMemory(device, stagingMemory, null);
-            stagingMemory = VK_NULL_HANDLE;
         }
     }
 
     private void destroyVulkanResources()
     {
         destroyEncodeResources();
-
-        VkDevice device = vulkanDevice.getDevice();
-        if (encodeFence != VK_NULL_HANDLE)
+        persistent.close();
+        for (int i = 0; i < EncodeResources.RING_DEPTH; i++)
         {
-            vkDestroyFence(device, encodeFence, null);
-            encodeFence = VK_NULL_HANDLE;
+            encodeFences[i] = VK_NULL_HANDLE;
+            uploadSemaphores[i] = VK_NULL_HANDLE;
         }
-        if (commandPool != VK_NULL_HANDLE)
-        {
-            vkDestroyCommandPool(device, commandPool, null);
-            commandPool = VK_NULL_HANDLE;
-        }
+        commandPool = VK_NULL_HANDLE;
+        gfxCommandPool = VK_NULL_HANDLE;
         vulkanInitialized = false;
     }
 


### PR DESCRIPTION
Been wanting to get video clip storage local for a while, and this PR gets there. Vulkan Video Encode takes the JPEG ring (still populated via the existing OpenGL capture path) and produces an H.264 MP4 on the user's own machine, organized by event type under ~/.runelite/osrs-tracker-clips/. Platform uploads become an explicit opt-in toggle paired with the existing token gate, so anyone without a token now gets a fully offline recorder.

720p output cap, bounded by the single-thread JPEG encode budget rather than the Vulkan side. Fallback to the MJPEG-to-server path when a GPU doesn't advertise VK_KHR_video_encode_h264, which covers macOS and older hardware.

Depends on runelite/runelite#20064 (LWJGL 3.3.6 bump + lwjgl-vulkan added to runelite-client).

Built with AI assistance, specifically Claude Opus 4.7, over a handful of iteration passes. The Co-Authored-By trailer is on the commit. Flagging it up-front because the review touches new territory and reviewers should know what was involved.
